### PR TITLE
Fix radio buttons for pre and post qual filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,7 +246,7 @@
             </p>
             <p>
               <ul>
-                <li>Stipend is the annual, 12-month allowance kindly bestowed by the institution</li>
+                <li>Stipend is the annual, 12-month allowance graciously provided by the institution</li>
                 <li>Fees are annual non-reimbursible tariffs reclaimed by said institution</li>
                 <li>Living cost is calculated based on the <a href="https://livingwage.mit.edu/">MIT Living Wage Calculator </a> for the institution's city</li>
               </ul>
@@ -264,6 +264,12 @@
 		<br>
                 <input type="checkbox" id="living-wage" checked>
                 <label for="living-wage"> Rank after subtracting non-reimbursable fees and local living cost</label><br>
+                <form>
+                  <input type="radio" id="pre-qual" name="qual" value="pre-qual" checked>
+                  <label for="html">Pre-Qualification</label>
+                  <input type="radio" id="post-qual" name="qual" value="post-qual">
+                  <label for="css">Post-Qualification</label>
+                </form>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Radio buttons for pre- and post- qualification filtering was broken in the previous commit. This request addresses the issue.