### PR TITLE
Revise fee amount for Georgia Tech

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -1,7 +1,7 @@
 "University of Michigan, Ann Arbor", 36072, 36072, 38838, 0,public, Yes
 "University of Illinois Urbana-Champaign (CSE)", 38850, 40854, 36657, 1266,public
 "University of Illinois Urbana-Champaign (ECE)", 33456, 35760, 36657, 1266,public
-"Georgia Institute of Technology", 31320, 34800, 39375, 3081,public
+"Georgia Institute of Technology", 31320, 34800, 39375, 1982,public
 "Harvard University", 42588, 42588, 46993, 0,private, Yes
 "University of Wisconsin - Madison", 30969, 34073, 36371, 1903,public
 "Rice University", 35400, 35400, 35487, 900,private


### PR DESCRIPTION
Total fee for 1 year is now: $1982 = $753 (Fall) + $753 (Spring) + $476 (Summer) Since Fall 2022, "Special Institutional Fee" was removed. https://www.bursar.gatech.edu/tuition-fees

- **Institution name(s)**:  Georgia Institute of Technology

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: https://www.bursar.gatech.edu/tuition-fees

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: 
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

- **Additional Comments (Optional)**: Since Fall 2022, "Special Institutional Fee" was removed.

- **Notify**: @mjc0608 @jiong-zhu @pyjhzwh @eltsai