### PR TITLE
Revise GT Fee Amount

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -1,7 +1,7 @@
 "University of Michigan, Ann Arbor", 36072, 36072, 38838, 0,public, Yes
 "University of Illinois Urbana-Champaign (CSE)", 38850, 40854, 36657, 1266,public
 "University of Illinois Urbana-Champaign (ECE)", 33456, 35760, 36657, 1266,public
-"Georgia Institute of Technology", 31320, 34800, 39375, 1982,public
+"Georgia Institute of Technology", 31320, 34800, 39375, 3081,public
 "Harvard University", 42588, 42588, 46993, 0,private, Yes
 "University of Wisconsin - Madison", 30969, 34073, 36371, 1903,public
 "Rice University", 35400, 35400, 35487, 900,private


### PR DESCRIPTION
Besides the fees shown on the bursar website, GT also charges PhD students healthcare, $25 tuition, and international student fees.

- **Institution name(s)**: 

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: 

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: 
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

- **Additional Comments (Optional)**: 

- **Notify**: @mjc0608 @jiong-zhu @pyjhzwh @eltsai