### PR TITLE
Update New York University - Courant

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -22,7 +22,7 @@
 "Cornell University", 43326, 43326, 37986, 0,private
 "Princeton University", 48000, 48000, 38001, 0,private
 "Northwestern University", 35196, 35196, 39900, 0,private
-"New York University - Courant", 54041, 54041, 46826, 0,private
+"New York University - Courant", 48036, 48036, 46826, 0,private
 "Johns Hopkins University", 43000, 43000, 37422, 0,private
 "The University of Texas at Austin", 31599, 31599, 31007, 0,public
 "Boston University", 44290, 44290, 46993, 0,private


### PR DESCRIPTION
The diff could come from summer funding. Usually, NYU provides 2 months stipend during summer so if some profs provide 3 months, it will have a 6000 diff. Info comes from a friend at NYU.

- **Institution name(s)**: 

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: 

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: 
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

- **Additional Comments (Optional)**: 

- **Notify**: @mjc0608 @jiong-zhu @pyjhzwh @eltsai