### PR TITLE
Revise GT fee to exclude insurance

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -1,7 +1,7 @@
 "University of Michigan, Ann Arbor", 36072, 36072, 38838, 0, public, Yes
 "University of Illinois Urbana-Champaign (CSE)", 38850, 40854, 36657, 1266, public
 "University of Illinois Urbana-Champaign (ECE)", 33456, 35760, 36657, 1266, public
-"Georgia Institute of Technology", 31320, 34800, 39375, 3081, public
+"Georgia Institute of Technology", 31320, 34800, 39375, 2182, public
 "Harvard University", 42588, 42588, 46993, 0, private, Yes
 "University of Wisconsin - Madison", 30969, 34073, 36371, 1903, public, No
 "Rice University", 35400, 35400, 35487, 900, private


### PR DESCRIPTION
Thanks @WillLester for pointing out the international student fee ($100) in #27 ! The total fee for international students would then be $2182 (= [$853 for Fall](https://www.bursar.gatech.edu/student/tuition/Fall_2022_totalspage.pdf) + [$853 for Spring](https://bursar.gatech.edu/student/tuition/Spring_2023_totalspage.pdf) + [$476 for Summer](https://bursar.gatech.edu/student/tuition/Summer%202023%20totals%2004272023.pdf))
For domestic students, the total fee is $1982 (the number used in #26 ), as that fee applies to the Spring and Fall semester (but not Summer semester). 

For the health insurance cost, it is already included in the "Living Cost" column as described by the [methodology of the Living Wage Calculator](https://livingwage.mit.edu/pages/methodology). Including health insurance again in the "Fees" column would mean that health insurance is counted twice.

It is common for universities to require (thus mandatory) their PhD students to have health insurance, and the university provides a default health insurance plan that students can [waive](https://www.bursar.gatech.edu/mandatory-student-insurance) (more examples at [Stanford](https://vaden.stanford.edu/insurance/choosing-your-insurance/waiving-cardinal-care-international-students) and [CMU](https://www.cmu.edu/health-services/student-insurance/)) if they have their own plans that meet the universities' requirements. Students would pay for some amount of the health insurance not subsidies by the university. For example CMU's annual SHIP health insurance premium (for student only) is [$2262.96 without CMU's subsidy](https://www.cmu.edu/health-services/student-insurance/plans.html) and it is [$1130 with CMU's 50% subsidy](https://www.cmu.edu/stugov/gsa/campus-advocacy/stipend-report-2021-2022.html). Georgia Tech's [annual SHIP health insurance premium (for student only) is $1144.52](https://www.bursar.gatech.edu/student/tuition/Fall_2022_totalspage.pdf) (Fall $303.48 + Spring $420.52 + Summer $420.52). In summary, health insurance (whether it is at Georgia Tech, or other universities like CMU) is not a fee --- rather, it is already included in the "Living Cost" column. (If we wish to include health insurance in the "Fees" column, then we would need to figure out what each university's default health insurance premium is and add that amount to each university's Fees accordingly.)

- **Institution name(s)**: Georgia Institute of Technology

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: 
https://livingwage.mit.edu/pages/methodology
https://www.bursar.gatech.edu/mandatory-student-insurance
https://www.bursar.gatech.edu/student/tuition/Fall_2022_totalspage.pdf
https://bursar.gatech.edu/student/tuition/Spring_2023_totalspage.pdf
https://bursar.gatech.edu/student/tuition/Summer%202023%20totals%2004272023.pdf


- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: 
https://livingwage.mit.edu/pages/methodology
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

- **Additional Comments (Optional)**: 

- **Notify**: @mjc0608 @jiong-zhu @pyjhzwh @eltsai