### PR TITLE
Update living cost for institutions in New York

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -18,11 +18,11 @@
 "Northeastern University", 50000, 50000, 46993, 869, private
 "University of California, Santa Barbara", 40000, 40000, 51681, 0, public
 "Brown University", 43712, 43712, 36228, 0, private
-"New York University - Tandon", 40800, 40800, 46826, 0, private
+"New York University - Tandon", 40800, 40800, 53342, 0, private
 "Cornell University", 43326, 43326, 37986, 0, private
 "Princeton University", 48000, 48000, 38001, 0, private
 "Northwestern University", 35196, 35196, 39900, 0, private
-"New York University - Courant", 48036, 48036, 46826, 0, private
+"New York University - Courant", 48036, 48036, 53342, 0, private
 "Johns Hopkins University", 43000, 43000, 37422, 0, private
 "The University of Texas at Austin (ECE)", 31600, 31600, 38171, 0, public
 "The University of Texas at Austin (CS)", 38400, 38400, 38171, 0, public
@@ -44,7 +44,7 @@
 "University of Massachusetts - Amherst", 37533, 37533, 33866, 0, public, No
 "The University of Texas at Dallas",23400,25800,36973,50, public
 "Arizona State University",21000,25800,38043,0, public, No
-"Columbia University",50120,50120,46826,50, private, Yes
+"Columbia University",50120,50120,53342,50, private, Yes
 "University of Illinois at Chicago", 30120, 30120, 38929, 0, public
 "Texas A&M University", 27000, 27000, 32972, 15, public, Yes
 "University of California, Los Angeles", 42600, 42600, 44783, 180, public


### PR DESCRIPTION
- **Institution name(s)**: New York University - Tandon, New York University - Courant, Columbia University

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: N/A - not updated

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: https://livingwage.mit.edu/counties/36061 and https://livingwage.mit.edu/counties/36047
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

- **Additional Comments (Optional)**: Following the reasoning in https://github.com/CSStipendRankings/CSStipendRankings/issues/35#issuecomment-1537041473, the statistics from [New York County](https://www.google.com/maps/place/New+York+County,+New+York,+NY/@40.7809816,-74.0597582,12z/data=!3m1!4b1!4m6!3m5!1s0x89c2ed64fc3b013b:0xd813d2023b2ead16!8m2!3d40.7830603!4d-73.9712488!16s%2Fg%2F121pkrcy) (Manhattan district) may be more accurate than the statistics for the large [New York-Newark-Jersey City Metropolitan Areas](https://www.google.com/maps/place/New+York+Metropolitan+Area/@40.772625,-74.8871948,8z/data=!3m1!4b1!4m6!3m5!1s0x89c286d6e07696fb:0xca34053f4678c888!8m2!3d40.7127761!4d-74.0059544!16s%2Fg%2F11cn6k49x1) for New York University - Courant and Columbia University. New York University - Tandon is in [Kings County (Brooklyn)](https://www.google.com/maps/place/Kings+County,+Brooklyn,+NY/@40.6453324,-74.0272351,12z/data=!3m1!4b1!4m6!3m5!1s0x89c2ed64fc3b013b:0xa3233f6e856bbeb3!8m2!3d40.6528762!4d-73.959494!16s%2Fg%2F120wl67j), which is the same as Manhattan. 

**We may need to check that for other institutions in large cities too.**