### PR TITLE
Update University of California Santa Cruz stipend

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -7,7 +7,7 @@
 "Rice University", 40333, 40333, 35487, 0, private
 "Stanford University", 52560, 52560, 55396, 0, private, Yes
 "University of Virginia", 33000, 35000, 38688, 0, public
-"University of California - Santa Cruz", 34500, 39200, 54095, 0, public
+"University of California - Santa Cruz", 40675, 46817, 54095, 0, public
 "Stony Brook University - SUNY", 33500, 33500, 35886, 0, public
 "University of Rochester", 37668, 37668, 32995, 0, private
 "University of Utah", 32600, 34800, 37038, 1800, public


### PR DESCRIPTION
This assumes student is a 50% GSR during the school year and 100% GSR in the summer:

Pre-ATC is step 1:
5090/month @ 100%
(5090/2)*9 + 5090*3 = 38175 / year

Post-ATC is step 3:
5909/month @ 100%
(5909/2)*9 + 5909*3 = 44317 / year

We also offer a $2500 housing stipend to all graduate students. So,

pre-ATC: 40675
post-ATC: 46817

Salaries updated as of 4/1/23 salary table:
https://apo.ucsc.edu/docs/scales-crnt.pdf

I'm assuming that students get summer support since other institutions are including it. I filed another issue to discuss these methodologies.

- **Institution name(s)**: 

University of California Santa Cruz

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: 

Salaries updated as of 4/1/23 salary table:
https://apo.ucsc.edu/docs/scales-crnt.pdf

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: 
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

- **Additional Comments (Optional)**: 
I'm assuming that students get summer support since other institutions are including it. I filed another issue to discuss these methodologies.
