### PR TITLE
Toggle for adding fellowship data (Looking to address #38)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.venv
+.python-version

--- a/fellowship-us.csv
+++ b/fellowship-us.csv
@@ -1,5 +1,5 @@
 "NSF Graduate Research Fellowship", 37000, 37000, N/A, N/A, fellowship, Yes
 "DOE Computational Science Graduate Fellowship", 45000, 45000, N/A, N/A, fellowship, Yes
-"National Defense Science and Engineering Graduate Fellowship Program", 40800, 40800, N/A, N/A, fellowship, Yes
+"NDSEG Fellowship Program", 40800, 40800, N/A, N/A, fellowship, Yes
 "Hertz Fellowship", 38000, 38000, N/A, N/A, fellowship, No
 "Meta Research PhD Fellowship", 42000, 42000, N/A, N/A, fellowship, Yes

--- a/fellowship-us.csv
+++ b/fellowship-us.csv
@@ -1,0 +1,5 @@
+"NSF Graduate Research Fellowship", 37000, 37000, N/A, N/A, fellowship, Yes
+"DOE Computational Science Graduate Fellowship", 45000, 45000, N/A, N/A, fellowship, Yes
+"National Defense Science and Engineering Graduate Fellowship Program", 40800, 40800, N/A, N/A, fellowship, Yes
+"Hertz Fellowship", 38000, 38000, N/A, N/A, fellowship, No
+"Meta Research PhD Fellowship", 42000, 42000, N/A, N/A, fellowship, Yes

--- a/index.html
+++ b/index.html
@@ -276,7 +276,7 @@
                     <option value="public">Public</option>
                   </optgroup>
                 </select>
-                Private schools in 🟪. Public schools in 🟩.
+                Private schools in 🟪. Public schools in 🟩. Fellowships in 🟧.
                 <br>
                 <!-- <input type="checkbox" id="living-wage" checked>
                 <label for="living-wage"> Rank after subtracting non-reimbursable fees and local living cost</label><br> -->
@@ -298,6 +298,8 @@
                   <label for="html">Pre-Qualification &nbsp;</label>
                   <input type="radio" id="post-qual" name="qual" value="post-qual" class="sort-trigger"></input>
                   <label for="css">Post-Qualification</label>
+                  <input type="checkbox" id="fellowship" name="fellowship" value="fellowship" class="sort-trigger"></input>
+                  <label for="css">Show Fellowships</label>
                 </div>
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -298,8 +298,10 @@
                   <label for="html">Pre-Qualification &nbsp;</label>
                   <input type="radio" id="post-qual" name="qual" value="post-qual" class="sort-trigger"></input>
                   <label for="css">Post-Qualification</label>
+                </div>
+                <div>
                   <input type="checkbox" id="fellowship" name="fellowship" value="fellowship" class="sort-trigger"></input>
-                  <label for="css">Show Fellowships with Living Costs from institutions in</label>
+                  <label for="css">Show fellowships and set the living cost to the institution</label>
                   <select id="university_locations" name="university_locations" onchange="do_change_CoL(this.value)"></select>
                 </div>
               </div>

--- a/index.html
+++ b/index.html
@@ -299,7 +299,8 @@
                   <input type="radio" id="post-qual" name="qual" value="post-qual" class="sort-trigger"></input>
                   <label for="css">Post-Qualification</label>
                   <input type="checkbox" id="fellowship" name="fellowship" value="fellowship" class="sort-trigger"></input>
-                  <label for="css">Show Fellowships</label>
+                  <label for="css">Show Fellowships with Living Costs from institutions in</label>
+                  <select id="university_locations" name="university_locations" onchange="do_change_CoL(this.value)"></select>
                 </div>
               </div>
             </div>

--- a/js/csstipendrankings.js
+++ b/js/csstipendrankings.js
@@ -11,6 +11,25 @@ for (i = 0; i < data.length; i++) {
     }
 }
 
+fellowship_csv = $.ajax({ type: "GET", url: "fellowship-us.csv", async: false }).responseText
+fellowship_data = $.csv.toArrays(fellowship_csv)
+for (i = 0; i < fellowship_data.length; i++) {
+    fellowship_data[i][1] = Number(fellowship_data[i][1]) // pre_qual stipend
+    fellowship_data[i][2] = Number(fellowship_data[i][2]) // after_qual stipend
+    // fellowship_data[i][3] = Number(fellowship_data[i][3]) // fee
+    // fellowship_data[i][4] = Number(fellowship_data[i][4]) // living cost
+    fellowship_data[i][5] = fellowship_data[i][5].trimStart()
+    if (fellowship_data[i].length == 7) {
+        fellowship_data[i][6] = fellowship_data[i][6].trimStart()
+    }
+}
+
+data.push.apply(data, fellowship_data)
+
+function use_fellowship() {
+    return $("#fellowship").is(":checked")
+}
+
 function is_subtract_living() {
     return $("#living-wage").is(":checked")
 }
@@ -113,12 +132,14 @@ function sort_on_column(col, desc_or_asc) {
         if (get_stipend(data[i]) - get_fee(data[i]) < get_living_cost(data[i]))
             style = "color:red"
         namefix = ""
-        private_public_style = ""
+        institution_style = ""
 
         if (get_university_type(data[i]) == "public")
-            private_public_style = "color:green"
+            institution_style = "color:green"
         else if (get_university_type(data[i]) == "private")
-            private_public_style = "color:purple"
+            institution_style = "color:purple"
+        else if (get_university_type(data[i]) == "fellowship")
+            institution_style = "color:orange"
         if (i == 0)
             namefix = " &#129351;"
         else if (i == 1)
@@ -134,8 +155,24 @@ function sort_on_column(col, desc_or_asc) {
         if (summer_funding == "Y" || summer_funding == "Yes")
             namefix2 = $("<span>").text(" summer").attr("class", "areaname systems-area")
 
-        if (get_institue_type_selected() == "all_public_private" ||
-            (get_institue_type_selected() == get_university_type(data[i]))
+        if (use_fellowship() && get_university_type(data[i]) == "fellowship") {
+            global_ranking_postfix = ""
+            if (get_institue_type_selected() != "all_public_private")
+                global_ranking_postfix = " (" + (i + 1).toString() + ")"
+            $("#ranking").find("tbody").append(
+                $("<tr>")
+                    .append($("<td>").text(local_rank + 1))
+                    .append($("<td>").text(get_university(data[i])).append(namefix).append(namefix2).attr("style", institution_style))
+                    .append($("<td>").text(get_stipend(data[i]).toLocaleString("en-US")).attr("align", "right"))
+                    .append($("<td>").text(get_fee(data[i]).toLocaleString("en-US")).attr("align", "right"))
+                    .append($("<td>").text(get_living_cost(data[i]).toLocaleString("en-US")).attr("align", "right"))
+                    .append($("<td>").text(("N/A").toLocaleString("en-US")).attr("align", "right").attr("style", style))
+            )
+            local_rank = local_rank + 1
+        }
+
+        if (get_university_type(data[i]) != "fellowship" && (get_institue_type_selected() == "all_public_private" ||
+            (get_institue_type_selected() == get_university_type(data[i])))
         ) {
             global_ranking_postfix = ""
             if (get_institue_type_selected() != "all_public_private")
@@ -143,7 +180,7 @@ function sort_on_column(col, desc_or_asc) {
             $("#ranking").find("tbody").append(
                 $("<tr>")
                     .append($("<td>").text(local_rank + 1))
-                    .append($("<td>").text(get_university(data[i])).append(namefix).append(namefix2).attr("style", private_public_style))
+                    .append($("<td>").text(get_university(data[i])).append(namefix).append(namefix2).attr("style", institution_style))
                     .append($("<td>").text(get_stipend(data[i]).toLocaleString("en-US")).attr("align", "right"))
                     .append($("<td>").text(get_fee(data[i]).toLocaleString("en-US")).attr("align", "right"))
                     .append($("<td>").text(get_living_cost(data[i]).toLocaleString("en-US")).attr("align", "right"))


### PR DESCRIPTION
Addressing #38

Looking for feedback. I'm trying to find a good way to display fellowship data such that it can accomplish two things:
(1) Address how the popular fellowships lag behind many institutions as several stipends have shot-up nationally this past year. This somewhat diminishes the draw of their competitiveness and reduces them to an accolade rather than any sort of financial advantage. (Acknowledging that industry connections/collaborations some offer is a worthwhile benefit.)
(2) See how the fellowship stipend compares to cost-of-living at a given institution.

Something that I am unsure how to display but feel could be important would be whether or not the fellowship covers fees and/or health insurance. Currently, the displayed data assumes there are no fees required for those on these fellowships since the fellowships I include here all cover institutional fees. I'm not sure if this is always the case.