### PR TITLE
Update fees for CMU

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -30,7 +30,7 @@
 "University of Southern California", 42000, 42000, 44142, 0, private, Unknown, Unknown, Unknown, No, No
 "University of North Carolina - Chapel Hill", 42931, 42931, 36024, 0, public, X2, Unknown, Unknown, Yes, Yes
 "Ohio State University - Columbus", 28373, 30000, 33579, 1052, public, No, Unknown, Unknown, No, No
-"Carnegie Mellon University", 38400, 38400, 33387, 1605, private, Unknown, Unknown, Unknown, No, No
+"Carnegie Mellon University", 38400, 38400, 33387, 0, private, Unknown, Unknown, Unknown, No, No
 "North Carolina State University", 30482, 30482, 38084, 4078, public, Unknown, Unknown, Unknown, No, No
 "Lehigh University", 29400, 29400, 34815, 0, private, Unknown, Unknown, Unknown, No, No
 "Pennsylvania State University - University Park", 30928, 30928, 37545, 0, public, Unknown, Unknown, Unknown, No, No


### PR DESCRIPTION
- **Institution name**: Carnegie Mellon University

- **Source of fee data**: As of Fall 2022, all PhD students at CMU receive full coverage of health insurance premiums. [News article here](http://thetartan.org/2022/3/21/news/phdstipends). As far as other fees, they are all covered by the "full financial support" of the school: [link](https://www.cmu.edu/sfs/tuition/graduate/scs.html), [link](https://www.cs.cmu.edu/academics/phd/programs). Therefore these values should not be deducted from the stipend. 