### PR TITLE
Fix a minor spelling error in a tooltip

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,7 +336,7 @@
                       </abbr><!--&nbsp;<span class="sort-indicator"></span>-->
                     </th>
                     <th data-column="fees" align="right">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-                      <abbr title="Non-reimbursable fees (including insurrance) charged by the university.">
+                      <abbr title="Non-reimbursable fees (including insurance) charged by the university.">
                         <font color="#777">Fees ($)</font>
                       </abbr><!--&nbsp;<span class="sort-indicator"></span>-->
                     </th>


### PR DESCRIPTION
"insurrance" -> "insurance"