### PR TITLE
Update UMD to 20-hr summers in stipend-us.csv

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -37,7 +37,7 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "Pennsylvania State University", 30928, 30928, 37545, 0, public, Unknown, Unknown, Unknown, No, No
 "Massachusetts Institute of Technology", 46548, 50016, 46993, 396, private, Unknown, Unknown, Unknown, No, No
 "University of Notre Dame", 37000, 37000, 33571, 0, private, Unknown, Unknown, Unknown, No, No
-"University of Maryland - College Park", 44348, 47633, 46403, 1603, public, No, 15286, 16419, Yes, Yes
+"University of Maryland - College Park", 36705, 39424, 46403, 1603, public, No, 15286, 16419, Yes, Yes
 "University of Washington", 48015, 52080, 44686, 789, public, X2, Unknown, Unknown, No, No
 "College of William and Mary", 29000, 29000, 38209, 0, public, Unknown, Unknown, Unknown, No, No
 "Univ. of California - San Diego", 41172, 44340, 47021,0, public, Unknown, Unknown, Unknown, No, No


### PR DESCRIPTION
Old numbers for University of Maryland, College Park were for 40hr summers, which was not what most students get -> changed to 20hr summer rate which is more common.

- **Institution name(s)**: University of Maryland, College Park

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: Added file with official GA rates (link at bottom)

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: 
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

[FY23 GA RATES COMP SCI_11-1-22_COLA.pdf](https://github.com/CSStipendRankings/CSStipendRankings/files/11456388/FY23.GA.RATES.COMP.SCI_11-1-22_COLA.pdf)

- **Additional Comments (Optional)**: 