### PR TITLE
Create stipend-eu.csv

### DIFF
--- a/stipend-eu.csv
+++ b/stipend-eu.csv
@@ -1,2 +1,2 @@
 institution, pre_qual stipend, after_qual stipend, living cost, fee, public/private, labels, pre_qual stipend, after_qual stipend, pre_qual verified, post_qual verified
-"University College London (UCL)", 19968, 19668, 24000, 0, public, summer-gtd, unknown, unknown, Yes, Yes
+"University College London (UCL)", 19668, 19668, 24000, 0, public, summer-gtd, unknown, unknown, Yes, Yes

--- a/stipend-eu.csv
+++ b/stipend-eu.csv
@@ -1,0 +1,2 @@
+institution, pre_qual stipend, after_qual stipend, living cost, fee, public/private, labels, pre_qual stipend, after_qual stipend, pre_qual verified, post_qual verified
+"University College London (UCL)", 19968, 19668, 24000, 0, public, summer-gtd, unknown, unknown, Yes, Yes


### PR DESCRIPTION
As per https://github.com/CSStipendRankings/CSStipendRankings/issues/52#issuecomment-1557776001, I have created a `stipend-eu.csv` file. In the UK, we do not have any pre/post-qual stipend. It is just a straightforward tax-free stipend that might increase annually as per "inflation."