### PR TITLE
Georgia Tech starts raising stipends since next semester

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -2,7 +2,7 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "University of Michigan", 36072, 36072, 38838, 0, public, summer-gtd varies striking, 12024, 12024, Y12, Y12
 "Univ. of Illinois at Urbana-Champaign (CSE)", 38850, 40854, 36657, 1266, public, summer-unknown, Unknown, Unknown, Yes, Yes
 "Univ. of Illinois at Urbana-Champaign (ECE)", 33456, 35760, 36657, 1266, public, summer-unknown, Unknown, Unknown, No, No
-"Georgia Institute of Technology", 31320, 34800, 39375, 3081, public, summer-unknown, Unknown, Unknown, No, No
+"Georgia Institute of Technology", 34560, 38400, 39375, 3081, public, summer-unknown, Unknown, Unknown, No, No
 "Harvard University", 42588, 42588, 46993, 0, private, summer-gtd, Unknown, Unknown, No, No
 "University of Wisconsin - Madison", 30969, 34073, 36371, 1903, public, summer-no-gtd no-guarantee, Unknown, Unknown, No, No
 "Rice University", 40333, 40333, 35487, 0, private, summer-unknown, Unknown, Unknown, No, No


### PR DESCRIPTION
- **Institution name(s)**: 

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: 

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: 
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

- **Additional Comments (Optional)**: 