### PR TITLE
Stony Brook CS is increasing stipend to 13K per semester starting Fall 2023

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -9,7 +9,7 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "Stanford University", 52560, 52560, 55396, 0, private, summer-gtd, Unknown, Unknown, No, No
 "University of Virginia", 33072, 35334, 38688, 0, public, summer-gtd, 11024, 11778, Yes, Yes
 "Univ. of California - Santa Cruz", 40675, 46817, 54095, 0, public, summer-unknown varies, Unknown, Unknown, No, No
-"Stony Brook University", 33500, 33500, 43345, 0, public, summer-unknown, Unknown, Unknown, No, No
+"Stony Brook University", 39000, 39000, 43345, 0, public, summer-unknown, Unknown, Unknown, No, No
 "University of Rochester (CS)", 41011, 41011, 32995, 0, private, summer-gtd, 9192, 9192, No, No
 "University of Utah", 34248, 35448, 37038, 300, public, summer-no-gtd varies, 8562, 8862, Y12 https://github.com/CSStipendRankings/CSStipendRankings/issues/74, Y12 https://github.com/CSStipendRankings/CSStipendRankings/issues/74
 "Purdue University (CS)", 25852, 25852, 33646, 1482, public, summer-unknown, Unknown, Unknown, No, No


### PR DESCRIPTION
- **Institution name(s)**:  Stony Brook University

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: I am a faculty member at SBU.

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: N/A
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

- **Additional Comments (Optional)**: 