### PR TITLE
Add CU Boulder

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -59,3 +59,4 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "Rochester Institute of Technology", 21000, 28000, 32995, 880, private, summer-no-gtd varies, Unknown, 7000, No, No
 "Washington University in St Louis", 37000, 37000, 33566, 500, private, summer-gtd, 9000, 9000, No, No
 "University of Pittsburg", 30000, 30000, 33387, 50, public, summer-gtd, 10000, 10000, No, No
+"University of Colorado - Boulder", 37200, 39996, 42341, 416, public, summer-no-gtd varies, 9300, 9999, No, No


### PR DESCRIPTION
Effective Fall 2023, the College of Engineering standardized stipends at 3100/month pre-comps and 3333/month post-comps at a standard 50% effort. Semester stipends are calculated at 4.5 months each.

Per CS department data for summer 2023, the median stipend is 75%, but the 20th percentile is 50% so I have calculated summer stipends at that level.

Boulder cost of living is 42341. https://livingwage.mit.edu/metros/14500

Fees are calculated as:

* Health insurance is assessed at 2311/semester (Aug 1 to Dec 31 and Jan 1 to July 31), but a TA or RA covers 91%, leaving 2*2311*0.09 = 416/year.
  * https://www.colorado.edu/health/cu-gold-ship
* Mandatory fees of 773/semester are assessed, but waived with TA or RA. A one-time new student fee, immigration compliance fee, and any voluntary fees are not covered by the waiver.
  * https://www.colorado.edu/bursar/costs/graduate-costs/graduate-costs-engineering#fall_2023_spring_2024-1535
  * https://www.colorado.edu/bursar/sites/default/files/attached-files/2023-24gradinrev100423.pdf
  * https://www.colorado.edu/bursar/sites/default/files/attached-files/2023-24gradoutintrev100423.pdf
  * https://www.colorado.edu/graduateschool/faculty-staff/funding-administration

The department provides a 5-year guarantee of TA support for PhD admits during the semesters, but that guarantee does not apply to summers.