### PR TITLE
Update Georgia Tech stipend

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -2,7 +2,7 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "University of Michigan", 36072, 36072, 38838, 0, public, summer-gtd varies, 12024, 12024, Y12, Y12
 "Univ. of Illinois at Urbana-Champaign (CSE)", 38850, 40854, 36657, 1266, public, summer-unknown, Unknown, Unknown, Yes, Yes
 "Univ. of Illinois at Urbana-Champaign (ECE)", 33456, 35760, 36657, 1266, public, summer-unknown, Unknown, Unknown, No, No
-"Georgia Institute of Technology", 34560, 38400, 39375, 3081, public, summer-unknown, Unknown, Unknown, No, No
+"Georgia Institute of Technology", 38400, 38400, 39375, 3081, public, summer-unknown, Unknown, Unknown, No, No
 "Harvard University", 42588, 42588, 46993, 0, private, summer-gtd, Unknown, Unknown, No, No
 "University of Wisconsin - Madison", 34097, 36074, 36371, 1903, public, summer-no-gtd no-guarantee, 8512, 9019, Yes https://github.com/CSStipendRankings/CSStipendRankings/issues/88, Yes https://github.com/CSStipendRankings/CSStipendRankings/issues/88
 "Rice University", 40333, 40333, 35487, 0, private, summer-unknown, Unknown, Unknown, No, No


### PR DESCRIPTION
- **Institution name(s)**: Georgia Institute of Technology

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: My own data point (School of Cybersecurity and Privacy PhD offer; Graduate Research Assistantship).

> The funding associated with your Graduate Research Assistantship, based on the current academic year costs, is as follows. Please note that these costs may marginally change and will be posted on the Bursar’s website as soon as they are available.
> - With the assistantship, your tuition will be reduced to $25 per term, as opposed to the standard tuition cost of $7,032 or $14,570 for in-state or out-of-state rates respectively.
> - You will be compensated with a monthly stipend of $3,200 paid on the last business day of each month equaling an annual rate of $38,400. This stipend is taxed as required by law. The stipend will help you pay for books, living expenses, insurance, etc. Additional information on estimates of these costs for graduate students can be found on the Office of Scholarships and Financial Aid’s website.
> - As for all graduate students, you will need to pay a mandatory student fee of $753 in the fall and in the spring and $476 in the summer. These fees provide access to campus resources like the health center and recreation center.
> - You will also be required to enroll in the Student Health Insurance Plan at a subsidized rate of $724 per year. Georgia Tech will pay the remaining $2,272 of the full cost of $2,996. Students with comparable existing coverage can waive this requirement.

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: [Atlanta-Sandy Springs-Alpharetta, GA](https://livingwage.mit.edu/metros/12060)
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.