### PR TITLE
Update stipend-us.csv for Northwestern University

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -22,7 +22,7 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "New York University (Tandon)", 40800, 40800, 53342, 0, private, summer-unknown varies, Unknown, Unknown, No, No
 "Cornell University", 43326, 43326, 37986, 0, private, summer-unknown, Unknown, Unknown, No, No
 "Princeton University", 48000, 48000, 38001, 0, private, summer-unknown, Unknown, Unknown, No, No
-"Northwestern University", 36960, 36960, 39900, 42, private, summer-gtd, 9240, 9240, No, No
+"Northwestern University", 45000, 45000, 39900, 42, private, summer-gtd, 11250, 11250, No, No
 "New York University (Courant)", 48036, 48036, 53342, 0, private, summer-unknown, Unknown, Unknown, No, No
 "Johns Hopkins University", 44300, 45500, 37422, 0, private, summer-unknown, Unknown, Unknown, Yes, No
 "University of Texas at Austin (ECE)", 31600, 31600, 38171, 0, public, summer-unknown, Unknown, Unknown, No, No


### PR DESCRIPTION
- **Institution name(s)**: 
Northwestern University

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: 
- Own data point, also at https://nugradworkers.org/full-tentative-agreement-bc-recommendation/. 45000 stipend will start 2024 fall

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: 
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

- **Additional Comments (Optional)**: 