### PR TITLE
Update stipend-us.csv for University of Notre Dame to reflect 2024-2025 stipend

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -36,7 +36,7 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "Lehigh University", 29400, 29400, 34815, 0, private, summer-unknown, Unknown, Unknown, No, No
 "Pennsylvania State University", 30928, 30928, 37545, 0, public, summer-unknown, Unknown, Unknown, No, No
 "Massachusetts Institute of Technology", 46548, 50016, 46993, 396, private, summer-unknown, Unknown, Unknown, No, No
-"University of Notre Dame", 37000, 37000, 33571, 0, private, summer-unknown, Unknown, Unknown, No, No
+"University of Notre Dame", 40000, 40000, 33571, 0, private, summer-unknown, Unknown, Unknown, No, No
 "University of Washington (CSE)", 46844, 48608, 44686, 789, public, summer-no-gtd varies, 16730, 17360, Yes https://grad.uw.edu/wp-content/uploads/2022-23-RA_salary_chart.pdf, Yes https://grad.uw.edu/wp-content/uploads/2022-23-RA_salary_chart.pdf
 "University of Washington (ECE)", 35489, 36834, 44686, 789, public, summer-no-gtd, 7715, 8007, Yes https://grad.uw.edu/wp-content/uploads/2022-23-RA_salary_chart.pdf, Yes https://grad.uw.edu/wp-content/uploads/2022-23-RA_salary_chart.pdf
 "College of William and Mary", 29000, 29000, 38209, 0, public, summer-unknown, Unknown, Unknown, No, No


### PR DESCRIPTION
- **Institution name(s)**: 

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: 

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: 
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

- **Additional Comments (Optional)**: 