### PR TITLE
Update stipend-us.csv to reflect Georgia Tech MIT Living wage (Fulton…

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -2,7 +2,7 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "University of Michigan", 36072, 36072, 38838, 0, public, summer-gtd varies, 12024, 12024, Y12, Y12
 "Univ. of Illinois at Urbana-Champaign (CSE)", 38850, 40854, 36657, 1266, public, summer-unknown, Unknown, Unknown, Yes, Yes
 "Univ. of Illinois at Urbana-Champaign (ECE)", 33456, 35760, 36657, 1266, public, summer-unknown, Unknown, Unknown, No, No
-"Georgia Institute of Technology", 38400, 38400, 39375, 3081, public, summer-unknown, Unknown, Unknown, No, No
+"Georgia Institute of Technology", 38400, 38400, 54296, 3081, public, summer-unknown, Unknown, Unknown, No, No
 "Harvard University", 42588, 42588, 46993, 0, private, summer-gtd, Unknown, Unknown, No, No
 "University of Wisconsin - Madison", 34067, 36074, 44480, 4040, public, summer-no-gtd no-guarantee survey=https://forms.gle/heDnnVJrmvZHtFPx7, 8512, 9019, Yes https://github.com/CSStipendRankings/CSStipendRankings/issues/88, Yes https://github.com/CSStipendRankings/CSStipendRankings/issues/88
 "Rice University", 40333, 40333, 35487, 0, private, summer-unknown, Unknown, Unknown, No, No


### PR DESCRIPTION
… County)

The MIT living wage number for Fulton county (Georgia Tech) was updated in February 2024. This update saw the living wage rise to $54296 for a single adult.

Source: https://livingwage.mit.edu/counties/13121

- **Institution name(s)**:  Georgia Tech

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**:  38400

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**:  https://livingwage.mit.edu/counties/13121
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

- **Additional Comments (Optional)**: 