### PR TITLE
Update JHU stipend

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -24,7 +24,7 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "Princeton University", 48000, 48000, 38001, 0, private, summer-unknown, Unknown, Unknown, No, No
 "Northwestern University", 45000, 45000, 50260, 42, private, summer-gtd, 11250, 11250, No, No
 "New York University (Courant)", 48036, 48036, 53342, 0, private, summer-unknown, Unknown, Unknown, No, No
-"Johns Hopkins University", 44300, 45500, 37422, 0, private, summer-unknown, Unknown, Unknown, Yes, No
+"Johns Hopkins University", 47000, 45500, 37422, 0, private, summer-unknown, Unknown, Unknown, Yes, No
 "University of Texas at Austin (ECE)", 31600, 31600, 38171, 0, public, summer-unknown, Unknown, Unknown, No, No
 "University of Texas at Austin (CS)", 38400, 38400, 38171, 0, public, summer-unknown, Unknown, Unknown, No, No
 "Boston University", 44290, 44290, 46993, 0, private, summer-unknown, Unknown, Unknown, No, No


### PR DESCRIPTION
- **Institution name(s)**:  Johns Hopkins 

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: 
https://hub.jhu.edu/2024/04/01/johns-hopkins-phd-student-union-agreement/

> The proposed CBA offers enhanced pay and benefits that raise the minimum stipend to $47,000 per year beginning this July.

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: 
N/A (not changing the living wages)  

  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

- **Additional Comments (Optional)**: 