### PR TITLE
Adding 'fees' value and 'cpt-fee' label to Stony Brook University

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -9,7 +9,7 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "Stanford University", 52560, 52560, 68624, 0, private, summer-gtd, Unknown, Unknown, No, No
 "University of Virginia", 33072, 35334, 50523, 0, public, summer-gtd, 11024, 11778, Yes, Yes
 "Univ. of California - Santa Cruz", 40675, 46817, 76215, 0, public, summer-unknown varies, Unknown, Unknown, No, No
-"Stony Brook University", 39000, 39000, 59557, 83, public, summer-no-gtd cpt-fee, 13000, 13000, No, No
+"Stony Brook University", 39000, 39000, 59557, 165, public, summer-no-gtd cpt-fee, 13000, 13000, No, No
 "University of Rochester (CS)", 41011, 41011, 44874, 0, private, summer-gtd, 9192, 9192, No, No
 "University of Utah", 34248, 35448, 47160, 300, public, summer-no-gtd varies, 8562, 8862, Y12 https://github.com/CSStipendRankings/CSStipendRankings/issues/74, Y12 https://github.com/CSStipendRankings/CSStipendRankings/issues/74
 "Purdue University (CS)", 25852, 25852, 40707, 1482, public, summer-unknown, Unknown, Unknown, No, No

--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -9,7 +9,7 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "Stanford University", 52560, 52560, 68624, 0, private, summer-gtd, Unknown, Unknown, No, No
 "University of Virginia", 33072, 35334, 50523, 0, public, summer-gtd, 11024, 11778, Yes, Yes
 "Univ. of California - Santa Cruz", 40675, 46817, 76215, 0, public, summer-unknown varies, Unknown, Unknown, No, No
-"Stony Brook University", 39000, 39000, 59557, 0, public, summer-no-gtd, 13000, 13000, No, No
+"Stony Brook University", 39000, 39000, 59557, 83, public, summer-no-gtd cpt-fee, 13000, 13000, No, No
 "University of Rochester (CS)", 41011, 41011, 44874, 0, private, summer-gtd, 9192, 9192, No, No
 "University of Utah", 34248, 35448, 47160, 300, public, summer-no-gtd varies, 8562, 8862, Y12 https://github.com/CSStipendRankings/CSStipendRankings/issues/74, Y12 https://github.com/CSStipendRankings/CSStipendRankings/issues/74
 "Purdue University (CS)", 25852, 25852, 40707, 1482, public, summer-unknown, Unknown, Unknown, No, No


### PR DESCRIPTION
- **Institution name(s)**: 
Stony Brook University

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: 

1. I have uploaded a redacted copy of my Fall semester's fee summary. I multiplied this number by 2 to account for the spring semester's fee.
[SU_ACCT_SUMM-redacted.pdf](https://github.com/user-attachments/files/16587905/SU_ACCT_SUMM-redacted.pdf)
Note: I overpaid the 'Personal Payment'. The total fee has to be calculated discarding that.

2. For CPT, we must register for a 1 credit course (refer to the following PDFs). If it is a summer internship, we end up paying for 1 credit of tution.
[Year-round Internships and Co-Ops for International Graduate CS Students](https://www.cs.stonybrook.edu/sites/default/files/drupalfiles/basicpage/Graduate%20Co-ops%20and%20internships%20year-round.pdf)
[GRADUATE STUDENT HANDBOOK](https://www.cs.stonybrook.edu/sites/default/files/drupalfiles/basicpage/GraduateHandbook.pdf)

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: 
Not applicable as I am not changing the "Living Cost" value.
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

- **Additional Comments (Optional)**: 