### PR TITLE
princeton '24-'25 stipend update

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -21,7 +21,7 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "Brown University", 43791, 43791, 48310, 0, private, summer-gtd, 10947, 10947, Yes, Yes
 "New York University (Tandon)", 40800, 40800, 61817, 0, private, summer-unknown varies, Unknown, Unknown, No, No
 "Cornell University", 43326, 43326, 51249, 0, private, summer-unknown, Unknown, Unknown, No, No
-"Princeton University", 48000, 48000, 51451, 0, private, summer-unknown, Unknown, Unknown, No, No
+"Princeton University", 52536, 52536, 51451, 0, private, summer-unknown, Unknown, Unknown, No, No
 "Northwestern University", 45000, 45000, 49273, 42, private, summer-gtd, 11250, 11250, No, No
 "New York University (Courant)", 48036, 48036, 58320, 0, private, summer-unknown, Unknown, Unknown, No, No
 "Johns Hopkins University", 47000, 45500, 49946, 0, private, summer-unknown, Unknown, Unknown, Yes, No


### PR DESCRIPTION
- **Institution name(s)**: 
Princeton University
- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: 
Own data point.
- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: 
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

- **Additional Comments (Optional)**: Base stipend pay.