### PR TITLE
Add Georgetown University to stipend-us.csv

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -61,4 +61,4 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "University of Pittsburgh", 30000, 30000, 43957, 50, public, summer-gtd, 10000, 10000, No, No
 "University of Colorado - Boulder", 37200, 39996, 54822, 416, public, summer-no-gtd varies cpt-fee, 9300, 9999, No, No
 "University at Buffalo", 29900, 29900, 43669, 3300, public, summer-no-gtd, 6900, 6900, No, No
-"Georgetown University", 38950, 38950, 56165, 0, private, summer-no-gtd cpt-fee, 38950, 38950, Yes, Yes  
+"Georgetown University", 38950, 38950, 56165, 0, private, summer-no-gtd cpt-fee, 38950, 38950, Yes https://github.com/CSStipendRankings/CSStipendRankings/pull/125, Yes https://github.com/CSStipendRankings/CSStipendRankings/pull/125

--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -61,3 +61,4 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "University of Pittsburgh", 30000, 30000, 43957, 50, public, summer-gtd, 10000, 10000, No, No
 "University of Colorado - Boulder", 37200, 39996, 54822, 416, public, summer-no-gtd varies cpt-fee, 9300, 9999, No, No
 "University at Buffalo", 29900, 29900, 43669, 3300, public, summer-no-gtd, 6900, 6900, No, No
+"Georgetown University", 38950, 38950, 56165, 0, private, summer-no-gtd cpt-fee, 38950, 38950, Yes, Yes  


### PR DESCRIPTION
Added new row with Current Stipend for Georgetown University

- **Institution name(s)**:  Georgetown Universuty

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**:  
    - Stipend: Union CBA Article 36 subsection a for 9-month https://drive.google.com/file/d/1J6Gfo4sw3kr_Dlkpd1sIrmhmtsSxShu3/view
    - CPT-Fee: Dept Handbook Section 4.16 : https://georgetown.app.box.com/s/hw252b4wxmul3cbpz55l2aqge2a4i7rc

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**:  https://livingwage.mit.edu/metros/47900
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

- **Additional Comments (Optional)**: 
Based on the CBA it will change each year - should we raise an issue in advance for me to update it?

**Testing Done**: 
Ran locally and checked visually for successfull load and info
<img width="1503" alt="Screenshot 2024-08-29 at 23 08 57" src="https://github.com/user-attachments/assets/603ea45a-0c35-4efa-91d8-b809add2990c">
