### PR TITLE
Fix Georgetown Summer Stipend and  README labels list

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 #### Option 1
 The fastest way to add or update the data is by [editing `stipend-us.csv`](https://github.com/CSStipendRankings/CSStipendRankings/edit/main/stipend-us.csv) and submit a [pull request](https://github.com/CSStipendRankings/CSStipendRankings/pulls). The stipend data are stored as rows in `stipend-us.csv` in the format of 
 
-> ```"<Institution Name (Optional Notes)>", <Annual Stipend Amount (Pre-Qualification) ($)>, <Annual Stipend Amount (Post-Qualification) ($)>,<Annual Local Living Wage ($)>, <Annual Out-of-pocket Fees (and Health Insurance) Charged by University ($)>, <Public or Private>, <Summer Funding Guarantee>```
+> ```"<Institution Name (Optional Notes)>", <Annual Stipend Amount (Pre-Qualification) ($)>, <Annual Stipend Amount (Post-Qualification) ($)>,<Annual Local Living Wage ($)>, <Annual Out-of-pocket Fees (and Health Insurance) Charged by University ($)>, <Public or Private>, <Labels such as Summer Funding Guarantee>, <Summer Stipend Amount (Pre-Qualification) ($)>, <Summer Stipend Amount (Post-Qualification) ($)>, <Is Pre Qualification Stipend verified (Add Link)>? <Is Post Qualification Stipend verified (Add Link)>?```
 
 Please place the institution name within `"`'s. Use the name however it appears on [CSRankings.org](https://csrankings.org/).
 

--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -61,4 +61,4 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "University of Pittsburgh", 30000, 30000, 43957, 50, public, summer-gtd, 10000, 10000, No, No
 "University of Colorado - Boulder", 37200, 39996, 54822, 416, public, summer-no-gtd varies cpt-fee, 9300, 9999, No, No
 "University at Buffalo", 29900, 29900, 43669, 3300, public, summer-no-gtd, 6900, 6900, No, No
-"Georgetown University", 38950, 38950, 56165, 0, private, summer-no-gtd cpt-fee, 38950, 38950, Yes https://github.com/CSStipendRankings/CSStipendRankings/pull/125, Yes https://github.com/CSStipendRankings/CSStipendRankings/pull/125
+"Georgetown University", 38950, 38950, 56165, 0, private, summer-no-gtd cpt-fee, Unknown, Unknown, Yes https://github.com/CSStipendRankings/CSStipendRankings/pull/125, Yes https://github.com/CSStipendRankings/CSStipendRankings/pull/125


### PR DESCRIPTION
Updated Georgetown summer stipend-to unknown
Expanded README label list to include Summer stipend and Verification Columns

- **Institution name(s)**:  Georgetown University

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**:   https://github.com/CSStipendRankings/CSStipendRankings/pull/125

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**:  NA
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

- **Additional Comments (Optional)**: 
Also changed README to mention summer labels