### PR TITLE
Update stipends for CU Boulder

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -59,6 +59,6 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "Rochester Institute of Technology", 21000, 28000, 44933, 880, private, summer-no-gtd varies, Unknown, 7000, No, No
 "Washington University in St Louis", 38500, 38500, 43898, 0, private, summer-gtd, 9625, 9625, Y12 https://github.com/CSStipendRankings/CSStipendRankings/issues/97, Y12 https://github.com/CSStipendRankings/CSStipendRankings/issues/97
 "University of Pittsburgh", 30000, 30000, 43957, 50, public, summer-gtd, 10000, 10000, No, No
-"University of Colorado - Boulder", 37200, 39996, 54822, 416, public, summer-no-gtd varies cpt-fee, 9300, 9999, No, No
+"University of Colorado - Boulder", 38688, 41596, 54822, 436, public, summer-no-gtd varies cpt-fee, 9672, 10399, No, No
 "University at Buffalo", 29900, 29900, 43669, 3300, public, summer-no-gtd, 6900, 6900, No, No
 "Georgetown University", 38950, 38950, 56165, 0, private, summer-no-gtd cpt-fee, Unknown, Unknown, Yes https://github.com/CSStipendRankings/CSStipendRankings/pull/125, Yes https://github.com/CSStipendRankings/CSStipendRankings/pull/125


### PR DESCRIPTION
In AY23-24, the monthly stipend was $3100/3333. A 4% raise was implemented at the college level for AY24-25, resulting in 3224/3466.

Health insurance is assessed at 2420/semester with TA/RA covering 91%. The remaining 9% for two semesters is 436.
https://www.colorado.edu/health/cu-gold-ship
