### PR TITLE
Added U Florida

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -62,3 +62,4 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "University of Colorado - Boulder", 38688, 41596, 54822, 436, public, summer-no-gtd varies cpt-fee, 9672, 10399, No, No
 "University at Buffalo", 29900, 29900, 43669, 3300, public, summer-no-gtd, 6900, 6900, No, No
 "Georgetown University", 38950, 38950, 56165, 0, private, summer-no-gtd cpt-fee, Unknown, Unknown, Yes https://github.com/CSStipendRankings/CSStipendRankings/pull/125, Yes https://github.com/CSStipendRankings/CSStipendRankings/pull/125
+"University of Florida", 32000, 32000, 41,675, 0, public, summer-unknown, Unknown, Unknown, Unknown


### PR DESCRIPTION
- **Institution name(s)**: University of Florida

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: It's the minimum I know because it constrains my PhD offers; also https://www.eng.ufl.edu/graduate/prospects/funding/

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: https://livingwage.mit.edu/metros/23540
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

- **Additional Comments (Optional)**:  Both CISE and ECE and other engineering departments. 32000 is the minimum allowed stipend for PhD hires. 