### PR TITLE
Princeton '25-'26 Stipend update

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -21,7 +21,7 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "Brown University", 52198, 52198, 42270, 0, private, summer-gtd, 13050, 13050, Y12 https://github.com/CSStipendRankings/CSStipendRankings/issues/132, Y12 https://github.com/CSStipendRankings/CSStipendRankings/issues/132
 "New York University (Tandon)", 40800, 40800, 61817, 0, private, summer-unknown varies, Unknown, Unknown, No, No
 "Cornell University", 43326, 43326, 51249, 0, private, summer-unknown, Unknown, Unknown, No, No
-"Princeton University", 52536, 52536, 51451, 0, private, summer-unknown, Unknown, Unknown, No, No
+"Princeton University", 54216, 54216, 51451, 0, private, summer-unknown, Unknown, Unknown, No, No
 "Northwestern University", 46356, 46356, 51752, 0, private, summer-gtd, 12938, 12938, Y12 https://github.com/CSStipendRankings/CSStipendRankings/issues/134, Y12 https://github.com/CSStipendRankings/CSStipendRankings/issues/134
 "New York University (Courant)", 48036, 48036, 58320, 0, private, summer-unknown, Unknown, Unknown, No, No
 "Johns Hopkins University", 47000, 45500, 49946, 0, private, summer-unknown, Unknown, Unknown, Yes, No


### PR DESCRIPTION
- **Institution name(s)**: Princeton University

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: sethkarten@princeton.edu

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: 
  
  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.

- **Additional Comments (Optional)**: 