### PR TITLE
Update Georgetown Stipend, and Living Cost for AY25-26

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -61,6 +61,6 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "University of Pittsburgh", 30000, 30000, 43957, 50, public, summer-gtd, 10000, 10000, No, No
 "University of Colorado - Boulder", 38688, 41596, 54822, 436, public, summer-no-gtd varies cpt-fee, 9672, 10399, No, No
 "University at Buffalo", 29900, 29900, 43669, 3300, public, summer-no-gtd, 6900, 6900, No, No
-"Georgetown University", 38950, 38950, 56165, 0, private, summer-no-gtd cpt-fee, Unknown, Unknown, Yes https://github.com/CSStipendRankings/CSStipendRankings/pull/125, Yes https://github.com/CSStipendRankings/CSStipendRankings/pull/125
+"Georgetown University", 39924, 39924, 60840, 0, private, summer-no-gtd cpt-fee, Unknown, Unknown, Yes https://github.com/CSStipendRankings/CSStipendRankings/pull/125, Yes https://github.com/CSStipendRankings/CSStipendRankings/pull/125
 "University of Florida", 32000, 32000, 41675, 0, public, summer-unknown, Unknown, Unknown, No, No
 "University of Tennessee - Knoxville", 35328, 35328, 46520, 0, public, summer-gtd, 8832, 8832, Y12 https://github.com/CSStipendRankings/CSStipendRankings/issues/136, Y12 https://github.com/CSStipendRankings/CSStipendRankings/issues/136


### PR DESCRIPTION
Update stipend-us.csv
Previous version: #125 

- **Institution name(s)**:  Georgetown University

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**:  GAGE CBA Article 36 subsection a for 9-month https://drive.google.com/file/d/1J6Gfo4sw3kr_Dlkpd1sIrmhmtsSxShu3/view

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**:  https://web.archive.org/web/20250624192452/https://livingwage.mit.edu/metros/47900 (Using wayback machine for a more static reference in the PR)
 
- **Additional Comments (Optional)**: 
  Refer #98 regarding disparate living wage due to unsynchronized updates. Erring towards being accurate for the university and leaving the rankings problem to #98.

- ** Testing Done** : 
Ran locally 
<img width="876" height="20" alt="Screenshot 2025-08-13 at 21-51-15 CSStipendRankings CS PhD Stipend Rankings" src="https://github.com/user-attachments/assets/9f83c395-b98c-426c-a9bd-984f08e5aeae" />
