### PR TITLE
Add University of Oregon stipend data

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -64,3 +64,4 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "Georgetown University", 39924, 39924, 60840, 0, private, summer-no-gtd cpt-fee, Unknown, Unknown, Yes https://github.com/CSStipendRankings/CSStipendRankings/pull/144, Yes https://github.com/CSStipendRankings/CSStipendRankings/pull/144
 "University of Florida", 32000, 32000, 41675, 0, public, summer-unknown, Unknown, Unknown, No, No
 "University of Tennessee - Knoxville", 35328, 35328, 46520, 0, public, summer-gtd, 8832, 8832, Y12 https://github.com/CSStipendRankings/CSStipendRankings/issues/136, Y12 https://github.com/CSStipendRankings/CSStipendRankings/issues/136
+"University of Oregon", 23232, 23232, 47680, 183, public, summer-no-gtd, Unknown, Unknown, No, No


### PR DESCRIPTION
- **Institution name(s)**:  University of Oregon

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: 
- My own Data Point
- https://graduatestudies.uoregon.edu/funding/ge/salary-benefits
- https://gtff3544.net/wp-content/uploads/2024/02/GTFF-CBA_2024-2026.pdf

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: https://livingwage.mit.edu/metros/21660


- **Additional Comments (Optional)**: Note that medical expenses should be lower compared to MIT estimate because the insurance is pretty strong. 