### PR TITLE
Add Vanderbilt University CS PhD stipend data (2026-2027)

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -67,3 +67,4 @@ institution, pre_qual stipend, after_qual stipend, living cost, fee, public/priv
 "University of Oregon", 23232, 23232, 47680, 183, public, summer-no-gtd, Unknown, Unknown, No, No
 "University of Minnesota", 32989, 32989, 51023, 325, public, summer-no-gtd, 8403, 8403, Yes https://cse.umn.edu/cs/assistantships, Yes https://cse.umn.edu/cs/assistantships
 "Kansas State University (CS)", 14400, 14400, 44627, 1378.48, public, summer-no-gtd varies, Unknown, Unknown, No, No
+"Vanderbilt University", 40000, 40000, 51243, 0, private, summer-gtd, Unknown, Unknown, No, No


### PR DESCRIPTION
- **Institution name(s)**: Vanderbilt University

- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**:
  - **Stipend ($40,000, 12-month, summer-guaranteed)**: Submitter data point for a 2026-2027 CS PhD admission. Vanderbilt's [School of Engineering Graduate Benefits page](https://engineering.vanderbilt.edu/academics/graduate/benefits/) publishes a school-wide *floor* of "TA and RA annual stipend award starting at $38,000 (Fall 2026)"; CS PhD offers come in at $40,000 — above the floor. Pre- and post-qualification stipends are the same (no documented post-qual bump at Vanderbilt CS).
  - **Summer funding (`summer-gtd`)**: Confirmed guaranteed by submitter; the $40,000 figure is the full 12-month stipend. The summer-only breakdown is not separately published, so listed as `Unknown` (matches the pattern used for Stanford, Harvard, U. Chicago, and other private peers with `summer-gtd` + `Unknown` summer breakdown).
  - **Fees ($0)**: [SoE Graduate Benefits](https://engineering.vanderbilt.edu/academics/graduate/benefits/) explicitly lists "Full tuition award", "Paid health insurance", and "Paid activity and recreation fees" as part of the doctoral package. The [Graduate School PhD Enhancements page](https://gradschool.vanderbilt.edu/costandfunding/phd/) confirms the SHIP premium (\$3,977/yr) is covered by the financial aid package. No documented out-of-pocket fees or CPT fee.
  - **Public/private**: Private.

- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: https://livingwage.mit.edu/counties/47037 (Davidson County, TN — Nashville)

  > Used the value in \`Typical Expenses → Required annual income before taxes → 1 Adult & 0 Children\` = **\$51,243**.

- **Additional Comments (Optional)**:
  - The stipend ($40,000) sits above the published SoE-wide floor of $38,000 because CS departments at Vanderbilt offer above the school floor for CS PhD admissions in 2026-2027, as it has moved out of engineering into the new College of Connected Computing (CCC): https://computing.vanderbilt.edu/graduate-programs/
  - Verified flags left as `No` since I have not attached a redacted offer letter to this PR. Happy to follow up via a [verification issue](https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose) per the FAQ to obtain the verified checkmark. I am the CCC Associate Dean for Graduate Education and confirm the information is accurate (see here: https://computing.vanderbilt.edu/faculty/#section-leadership).
  - No CS/ECE split is needed: Computer Science is the relevant CSRankings unit.