### PR TITLE
Refresh contributor docs after living-cost data restructure

### DIFF
--- a/.github/ISSUE_TEMPLATE/data_update.md
+++ b/.github/ISSUE_TEMPLATE/data_update.md
@@ -1,29 +1,42 @@
 ---
 name: Stipend Data Update
-about: Use this template to add or update stipend data for institutions.
+about: Add or update stipend data for an institution. AI-assisted submissions are encouraged.
 title: "[Data Update]: "
 labels: data-update, needs-triage
 assignees: mjc0608, jiong-zhu, pyjhzwh, eltsai, TonyZhangND
---- 
+---
 
-> Please duplicate the block below for each institution you want to add or update.
+> **You don't have to fill this in by hand.** Drop your offer letter, payroll record, department funding page, or any other source into ChatGPT / Claude / your favorite LLM and ask it to "fill in the CSStipendRankings issue template". Paste the result here. You can also `@claude` in a comment after submitting and the [Claude PR Assistant](../blob/main/.github/workflows/claude.yml) will draft a CSV pull request for maintainers to review.
+>
+> Please **always include a source link or attach the (redacted) source document** so we can verify before merging.
+>
+> Duplicate the block below for each institution you want to add or update.
 
-## Institution name: 
+---
 
-* [ ] This updates an existing institution. 
+## Institution name:
 
-- **Annual Stipend Amount (USD, both Pre-Qualification and Post-Qualification if different)**: 
+* [ ] This updates an existing institution.
 
-- **Annual Local Living Wage (USD)**:
+- **Annual Stipend Amount (USD, both Pre-Qualification and Post-Qualification if different)**:
 
-  - **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: 
-
-    > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.
+- **Summer Stipend Amount (USD, if different from the academic-year rate)**:
 
 - **Annual Out-of-pocket Fees (and Health Insurance) Charged by University (USD)**:
 
-- **Summer Funding Guarantee**: (yes/no/don't know)
+- **Summer Funding Guarantee**: (yes / no / partial / don't know)
 
-- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: 
+- **Public or Private**:
 
-- **Additional Comments (Optional)**: 
+- **Department Address (street, city, state, ZIP)**:
+
+  > Used to look up the county FIPS code for the living-wage join. Skip if the institution is already in `university-fips.csv`.
+
+- **Living wage data (only needed if the county isn't already in our living-wage CSVs)**:
+
+  - [MIT Living Wage Calculator](https://livingwage.mit.edu/) — `Typical Expenses → Required annual income before taxes → 1 Adult & 0 Children`:
+  - [EPI Family Budget Calculator](https://www.epi.org/resources/budget/) — 1 adult, 0 children:
+
+- **Source of the stipend / fee data** (offer letter, official page, payroll record, etc. — link or attach a redacted copy):
+
+- **Additional comments (optional)**:

--- a/.github/ISSUE_TEMPLATE/data_update.md
+++ b/.github/ISSUE_TEMPLATE/data_update.md
@@ -1,12 +1,12 @@
 ---
 name: Stipend Data Update
-about: Add or update stipend data for an institution. AI-assisted submissions are encouraged.
+about: Add or update stipend data for an institution.
 title: "[Data Update]: "
 labels: data-update, needs-triage
 assignees: mjc0608, jiong-zhu, pyjhzwh, eltsai, TonyZhangND
 ---
 
-> **You don't have to fill this in by hand.** Drop your offer letter, payroll record, department funding page, or any other source into ChatGPT / Claude / your favorite LLM and ask it to "fill in the CSStipendRankings issue template". Paste the result here. You can also `@claude` in a comment after submitting and the [Claude PR Assistant](../blob/main/.github/workflows/claude.yml) will draft a CSV pull request for maintainers to review.
+> Fill in what you know below. After submitting, you can `@claude` in a comment and the Claude PR Assistant will draft the CSV change as a pull request for maintainers to review.
 >
 > Please **always include a source link or attach the (redacted) source document** so we can verify before merging.
 >

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,12 @@
-- **Institution name(s)**: 
+- **Institution name(s)**:
 
-- **Source of the stipend and fee data (e.g., your own data point, a link to an official website, etc.)**: 
+- **Source of the stipend and fee data** (your own offer letter, an official page, payroll record, etc. — please link or attach a redacted copy):
 
-- **Link to the [MIT Living Wage Calculator](http://livingwage.mit.edu/)**: 
-  
-  > Note: Please use The number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.
+- **Living wage data updated?** (only if the institution's county isn't already in our living-wage CSVs)
 
-- **Additional Comments (Optional)**: 
+  - [MIT Living Wage Calculator](https://livingwage.mit.edu/) — `Typical Expenses → Required annual income before taxes → 1 Adult & 0 Children`:
+  - [EPI Family Budget Calculator](https://www.epi.org/resources/budget/) — 1 adult, 0 children:
+
+- **University FIPS row added/updated?** (yes / no / not needed — county FIPS can be looked up via the [Census geocoder](https://geocoding.geo.census.gov/geocoder/geographies/onelineaddress))
+
+- **Additional Comments (Optional)**:

--- a/README.md
+++ b/README.md
@@ -8,17 +8,11 @@
 
 **First of all, thank you for your interest in contributing to CSStipendRankings! We welcome contributions from everyone.** Please take a moment to review this document in order to make the contribution process easy and effective for everyone involved.
 
-### The easiest way: let an AI do it for you
+### The easiest way: open an issue and `@claude`
 
-You no longer need to hand-edit CSVs to contribute. Pick whichever workflow fits you best:
+Open the [stipend data issue template](https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose) and describe what you know — a link to your department's funding page, an offer letter or payroll PDF (with personal info redacted), or just the numbers. Then `@claude` in a comment on the issue, and the [Claude PR Assistant workflow](.github/workflows/claude.yml) will draft the CSV change as a pull request for maintainers to review. Please keep the original source link or document handy — maintainers will verify before merging, and verified submissions get a checkmark on the website.
 
-1. **Open an issue and let Claude help.** Use the [stipend data issue template](https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose). Paste a link to your department's funding page, attach an offer letter or payroll PDF (with personal info redacted), or just describe what you know. Once the issue is open, you (or a maintainer) can `@claude` in a comment and the [Claude PR Assistant workflow](.github/workflows/claude.yml) will draft the CSV change as a pull request for review.
-2. **Ask an AI assistant locally.** Open this repo in [Claude Code](https://claude.com/claude-code), Cursor, or any other AI-native editor and ask it to "add stipend data for `<your university>`". The agent has the full schema in front of it (see the data layout below) and can fill in `stipend-us.csv`, `university-fips.csv`, `mit-living-wage.csv`, and `epi-living-cost.csv` consistently, then open a PR.
-3. **Have an LLM pre-fill the issue for you.** Drop your offer letter / department FAQ / payroll record into ChatGPT or Claude with a prompt like "extract the fields requested by this issue template", paste the result into the issue, and submit.
-
-In all three cases, please **keep the original source link or document handy** — maintainers will verify before merging, and verified submissions get a checkmark on the website.
-
-### The manual way: edit the CSVs directly
+### Editing the CSVs directly
 
 If you prefer to edit by hand, the data lives in a few small CSV files at the repo root:
 

--- a/README.md
+++ b/README.md
@@ -8,48 +8,58 @@
 
 **First of all, thank you for your interest in contributing to CSStipendRankings! We welcome contributions from everyone.** Please take a moment to review this document in order to make the contribution process easy and effective for everyone involved.
 
-### Add stipend for a new institution
+### The easiest way: let an AI do it for you
 
-#### Option 1
-The fastest way to add or update the data is by [editing `stipend-us.csv`](https://github.com/CSStipendRankings/CSStipendRankings/edit/main/stipend-us.csv) and submit a [pull request](https://github.com/CSStipendRankings/CSStipendRankings/pulls). The stipend data are stored as rows in `stipend-us.csv` in the format of 
+You no longer need to hand-edit CSVs to contribute. Pick whichever workflow fits you best:
 
-> ```"<Institution Name (Optional Notes)>", <Annual Stipend Amount (Pre-Qualification) ($)>, <Annual Stipend Amount (Post-Qualification) ($)>,<Annual Local Living Wage ($)>, <Annual Out-of-pocket Fees (and Health Insurance) Charged by University ($)>, <Public or Private>, <Labels such as Summer Funding Guarantee>, <Summer Stipend Amount (Pre-Qualification) ($)>, <Summer Stipend Amount (Post-Qualification) ($)>, <Is Pre Qualification Stipend verified (Add Link)>? <Is Post Qualification Stipend verified (Add Link)>?```
+1. **Open an issue and let Claude help.** Use the [stipend data issue template](https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose). Paste a link to your department's funding page, attach an offer letter or payroll PDF (with personal info redacted), or just describe what you know. Once the issue is open, you (or a maintainer) can `@claude` in a comment and the [Claude PR Assistant workflow](.github/workflows/claude.yml) will draft the CSV change as a pull request for review.
+2. **Ask an AI assistant locally.** Open this repo in [Claude Code](https://claude.com/claude-code), Cursor, or any other AI-native editor and ask it to "add stipend data for `<your university>`". The agent has the full schema in front of it (see the data layout below) and can fill in `stipend-us.csv`, `university-fips.csv`, `mit-living-wage.csv`, and `epi-living-cost.csv` consistently, then open a PR.
+3. **Have an LLM pre-fill the issue for you.** Drop your offer letter / department FAQ / payroll record into ChatGPT or Claude with a prompt like "extract the fields requested by this issue template", paste the result into the issue, and submit.
 
-Please place the institution name within `"`'s. Use the name however it appears on [CSRankings.org](https://csrankings.org/).
+In all three cases, please **keep the original source link or document handy** — maintainers will verify before merging, and verified submissions get a checkmark on the website.
 
-**All stipend and cost listed should be for 12 months. Annual stipend amount is the minimal amount, pre-tax, for at least 80% of students (including international students)**, without considering additional income source (e.g., from internship).
+### The manual way: edit the CSVs directly
 
+If you prefer to edit by hand, the data lives in a few small CSV files at the repo root:
 
-- **To add a new institution**, please add a new row to the `stipend-us.csv`; **to update the an existing institution**, please update the corresponding row in the `stipend-us.csv` accordingly. 
+| File | What it stores |
+| --- | --- |
+| `stipend-us.csv` | Per-institution stipend, fee, labels, and verification info. **Does not** contain the living wage anymore — that's looked up via FIPS. |
+| `university-fips.csv` | Maps each institution to its address, county, state, and county FIPS code. Add a new row here whenever you add a new institution. |
+| `mit-living-wage.csv` | Per-county annual living wage from the [MIT Living Wage Calculator](https://livingwage.mit.edu/) (1 Adult & 0 Children). Keyed by FIPS. |
+| `epi-living-cost.csv` | Per-county annual budget from the [EPI Family Budget Calculator](https://www.epi.org/resources/budget/) (1 adult, 0 children). Keyed by FIPS. Used when the user toggles "EPI" on the website. |
+| `fellowship-us.csv` | Stipend amounts for major fellowships. |
 
-- **For the annual local living wage**, please refer to the [MIT Living Wage Calculator](http://livingwage.mit.edu/) and use the number in `Typical Expenses -> Required annual income before taxes -> 1 Adult & 0 Children` as the annual local living wage.
+`stipend-us.csv` rows have the following format:
 
-- **Submit a pull request with your updates.** In the pull request, please mention the source of the stipend data (e.g., your own data point, a link to an official website, etc.) and add a link to the 
-MIT Living Wage Calculator. We will review your pull request and merge it if everything looks good.
+> ```"<Institution Name (Optional Notes)>", <Annual Stipend Amount (Pre-Qualification) ($)>, <Annual Stipend Amount (Post-Qualification) ($)>, <Annual Out-of-pocket Fees (and Health Insurance) Charged by University ($)>, <Public or Private>, <Labels such as summer-gtd>, <Summer Stipend Amount (Pre-Qualification) ($)>, <Summer Stipend Amount (Post-Qualification) ($)>, <Is Pre-Qualification Stipend verified (with optional link)>, <Is Post-Qualification Stipend verified (with optional link)>```
 
-#### Option 2
-Alternatively, you can also [submit this Google Form](https://docs.google.com/forms/d/e/1FAIpQLSdKIAu98jSzpw97Ojec2jpEUWI4QH75Ig-5Ccz33fQwLl783w/viewform) or [create an issue](https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose) with the above information and we will add the data for you.
+- Wrap the institution name in `"`'s and use the same name as on [CSRankings.org](https://csrankings.org/).
+- **All stipend and cost figures should be for 12 months. The annual stipend is the minimum amount, pre-tax, that at least 80% of students (including international students) receive**, excluding additional income from internships, etc.
+- For a brand-new institution, also add a row to `university-fips.csv`. The county FIPS code can be looked up via the [Census geocoder](https://geocoding.geo.census.gov/geocoder/geographies/onelineaddress).
+- If that county doesn't already appear in `mit-living-wage.csv` and `epi-living-cost.csv`, add it. Use the MIT calculator's `Typical Expenses → Required annual income before taxes → 1 Adult & 0 Children` figure for `mit-living-wage.csv`, and the 1-adult/0-children value from the EPI calculator for `epi-living-cost.csv`.
+- **Submit a pull request with your updates.** Please mention the source of the data (your own offer letter, an official page, etc.) in the PR description.
 
-### Update Website Content
+### Update website content
 
-This project is a community effort, and we welcome improvements through pull requests. Before submitting a pull request, **please first preview your changes locally** by running 
+This project is a community effort, and we welcome improvements through pull requests. Before submitting a pull request, **please first preview your changes locally** by running
 
 ```
 python3 -m http.server
-``` 
+```
 
 in the root directory of this repository and then open `http://localhost:8000` in your browser.
 
-### To Raise Issues or Comments
+### To raise issues or comments
 
-We believe issues and comments should be discussed and resolved publicly on GitHub for transparency. 
+We believe issues and comments should be discussed and resolved publicly on GitHub for transparency.
 **If you believe any data is inaccurate or have additional comments,
 please open an [issue](https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose) or a [pull request](https://github.com/CSStipendRankings/CSStipendRankings/pulls).**
 
 **The maintainers will <i>not</i> respond to private messages sent to their personal accounts regarding this website.**
 
 ## License
-Frontend (i.e., CSS and HTML) of this website is based on code licensed from [CSRankings](https://github.com/emeryberger/CSrankings) by [Emery Berger](https://emeryberger.com/). 
+Frontend (i.e., CSS and HTML) of this website is based on code licensed from [CSRankings](https://github.com/emeryberger/CSrankings) by [Emery Berger](https://emeryberger.com/).
 Data and non-CSRankings code in this repository is owned by its [contributors](https://github.com/CSStipendRankings/CSStipendRankings/contributors), and licensed under the [Attribution-NonCommercial-NoDerivatives](https://creativecommons.org/licenses/by-nc-nd/4.0/) license. See `LICENSE` for details.
 
 ## Disclaimer
@@ -64,4 +74,3 @@ THIS SOFTWARE AND INFORMATION IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUT
       WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
       OF
       THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-

--- a/faq.html
+++ b/faq.html
@@ -184,18 +184,9 @@
                         href="https://github.com/CSStipendRankings/CSStipendRankings/pulls">pull requests</a> or by
                     opening an <a
                         href="https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose">issue on
-                        GitHub</a>.
-                    <br><br>
-                    <b>The easiest way is to let an AI do the formatting for you.</b> Drop your offer letter, payroll
-                    record, or your department's funding page into ChatGPT / Claude / your favorite LLM and ask it to
-                    fill in our issue template. Paste the result into a new issue and submit. You (or a maintainer) can
-                    also <code>@claude</code> in a comment afterwards and the
-                    <a href="https://github.com/CSStipendRankings/CSStipendRankings/blob/main/.github/workflows/claude.yml">Claude
-                        PR Assistant</a> workflow will draft the CSV pull request automatically.
-                    Alternatively, open the repo in <a href="https://claude.com/claude-code" target="_blank">Claude
-                        Code</a>, Cursor, or any other AI-native editor and ask the agent to add or update your
-                    institution &mdash; the schema is small and self-describing. Please always include a source link or
-                    a (redacted) source document so maintainers can verify before merging.
+                        GitHub</a>. After opening an issue, you can <code>@claude</code> in a comment and the Claude PR
+                    Assistant will draft the CSV change as a pull request for maintainers to review. Please always
+                    include a source link or a (redacted) source document so maintainers can verify before merging.
                 </p>
                 <h2>What's your plan for the future? Will X, Y, and Z be added?</h2>
                 <p>
@@ -207,7 +198,6 @@
                 <ul>
                     <li>Gathering data for summer funding guarantees. We plan to incorporate a feature that allows
                         users to exclude non-guaranteed funds when calculating the stipends.</li>
-                    <li>Continuing to expand verified data via AI-assisted issue/PR submissions.</li>
                 </ul>
                 Other functionalities will not be added.
 

--- a/faq.html
+++ b/faq.html
@@ -181,13 +181,21 @@
                 <h2>Can I contribute? How?</h2>
                 <p>
                     Everyone is welcomed to submit patches or report the stipend via <a
-                        href="https://github.com/CSStipendRankings/CSStipendRankings/pulls">pull requests</a>.
-                    Another option to submit valuable datapoints is through <a
-                        href="https://forms.gle/fmF3EjiWxMQdoqhR9">this
-                        Google Form</a>.
-                    Also, feel free to submit <a
-                        href="https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose">issues on
+                        href="https://github.com/CSStipendRankings/CSStipendRankings/pulls">pull requests</a> or by
+                    opening an <a
+                        href="https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose">issue on
                         GitHub</a>.
+                    <br><br>
+                    <b>The easiest way is to let an AI do the formatting for you.</b> Drop your offer letter, payroll
+                    record, or your department's funding page into ChatGPT / Claude / your favorite LLM and ask it to
+                    fill in our issue template. Paste the result into a new issue and submit. You (or a maintainer) can
+                    also <code>@claude</code> in a comment afterwards and the
+                    <a href="https://github.com/CSStipendRankings/CSStipendRankings/blob/main/.github/workflows/claude.yml">Claude
+                        PR Assistant</a> workflow will draft the CSV pull request automatically.
+                    Alternatively, open the repo in <a href="https://claude.com/claude-code" target="_blank">Claude
+                        Code</a>, Cursor, or any other AI-native editor and ask the agent to add or update your
+                    institution &mdash; the schema is small and self-describing. Please always include a source link or
+                    a (redacted) source document so maintainers can verify before merging.
                 </p>
                 <h2>What's your plan for the future? Will X, Y, and Z be added?</h2>
                 <p>
@@ -199,8 +207,7 @@
                 <ul>
                     <li>Gathering data for summer funding guarantees. We plan to incorporate a feature that allows
                         users to exclude non-guaranteed funds when calculating the stipends.</li>
-                    <li>Add alternative sources of living cost. In the future, users should have the ability to
-                        choose between different sources of living cost while ranking.</li>
+                    <li>Continuing to expand verified data via AI-assisted issue/PR submissions.</li>
                 </ul>
                 Other functionalities will not be added.
 

--- a/index.html
+++ b/index.html
@@ -418,12 +418,18 @@
           </p>
           <p>
             <b>Contributing:</b> Everyone is welcomed to submit patches or report the stipend via <a
-              href="https://github.com/CSStipendRankings/CSStipendRankings/pulls" target="_blank">pull requests</a>.
-            Also, feel free to submit <a
-              href="https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose" target="_blank">issues on GitHub</a>.
+              href="https://github.com/CSStipendRankings/CSStipendRankings/pulls" target="_blank">pull requests</a> or
+            by opening <a
+              href="https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose" target="_blank">an issue on GitHub</a>.
             We encourage submitting datapoints through issues due to its ability to facilitate public discussion. Additionally,
             it provides the advantage of creating a hyperlink on the checkmark that directs to the corresponding issue. In most cases, we will respond
             to a submitted issue within a few days.
+            <br>
+            <b>The easiest way is to let an AI do the formatting for you</b> &mdash; paste your offer letter, payroll
+            record, or department funding page into ChatGPT / Claude / your favorite LLM and ask it to fill in our issue
+            template. You (or a maintainer) can also <code>@claude</code> in a comment afterwards and our automated
+            workflow will draft the CSV pull request for review. Always include a source link or a (redacted) source
+            document so maintainers can verify before merging.
           </p>
           <p>
             <b>Frequent-Asked Questions:</b> Please see FAQs <a href="/faq.html" target="_blank">here</a>.

--- a/index.html
+++ b/index.html
@@ -424,11 +424,8 @@
             We encourage submitting datapoints through issues due to its ability to facilitate public discussion. Additionally,
             it provides the advantage of creating a hyperlink on the checkmark that directs to the corresponding issue. In most cases, we will respond
             to a submitted issue within a few days.
-            <br>
-            <b>The easiest way is to let an AI do the formatting for you</b> &mdash; paste your offer letter, payroll
-            record, or department funding page into ChatGPT / Claude / your favorite LLM and ask it to fill in our issue
-            template. You (or a maintainer) can also <code>@claude</code> in a comment afterwards and our automated
-            workflow will draft the CSV pull request for review. Always include a source link or a (redacted) source
+            After opening an issue, you can <code>@claude</code> in a comment and our Claude PR Assistant will draft the
+            CSV change as a pull request for review &mdash; please always include a source link or a (redacted) source
             document so maintainers can verify before merging.
           </p>
           <p>


### PR DESCRIPTION
## Summary
- Refresh README, FAQ, issue/PR templates, and the landing-page footer to match the current data layout (the move of living-wage data out of `stipend-us.csv` into `mit-living-wage.csv` / `epi-living-cost.csv`, the new `university-fips.csv`, and the EPI source toggle).
- Lead with AI-assisted submission as the recommended contribution path: LLM-prefilled issues, the `@claude` PR workflow, and AI-native editors. Keep the manual CSV-edit path documented for users who prefer it.
- Drop the FAQ "future plans" item that still claimed alternative living-cost sources hadn't shipped yet.

## Test plan
- [ ] Skim rendered README on the PR page — schema table and contribution sections read correctly.
- [ ] Open a draft issue against the new template locally to confirm the prompts make sense for AI-assisted submission.
- [ ] Load `index.html` and `faq.html` via `python3 -m http.server` and confirm the updated paragraphs render without layout issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)