### PR TITLE
Make source-document submission optional and tied to checkmark

### DIFF
--- a/.github/ISSUE_TEMPLATE/data_update.md
+++ b/.github/ISSUE_TEMPLATE/data_update.md
@@ -8,7 +8,7 @@ assignees: mjc0608, jiong-zhu, pyjhzwh, eltsai, TonyZhangND
 
 > Fill in what you know below. After submitting, you can `@claude` in a comment and the Claude PR Assistant will draft the CSV change as a pull request for maintainers to review.
 >
-> Please **always include a source link or attach the (redacted) source document** so we can verify before merging.
+> Source documents are **optional but encouraged**: if you can share a link or upload a (redacted) copy, we can add a verified checkmark on the website.
 >
 > Duplicate the block below for each institution you want to add or update.
 
@@ -37,6 +37,6 @@ assignees: mjc0608, jiong-zhu, pyjhzwh, eltsai, TonyZhangND
   - [MIT Living Wage Calculator](https://livingwage.mit.edu/) — `Typical Expenses → Required annual income before taxes → 1 Adult & 0 Children`:
   - [EPI Family Budget Calculator](https://www.epi.org/resources/budget/) — 1 adult, 0 children:
 
-- **Source of the stipend / fee data** (offer letter, official page, payroll record, etc. — link or attach a redacted copy):
+- **Source of the stipend / fee data** (optional — offer letter, official page, payroll record, etc.; a link or redacted upload qualifies you for a verified checkmark):
 
 - **Additional comments (optional)**:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 - **Institution name(s)**:
 
-- **Source of the stipend and fee data** (your own offer letter, an official page, payroll record, etc. — please link or attach a redacted copy):
+- **Source of the stipend and fee data** (optional — your own offer letter, an official page, payroll record, etc.; a link or redacted upload qualifies the entry for a verified checkmark):
 
 - **Living wage data updated?** (only if the institution's county isn't already in our living-wage CSVs)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ### The easiest way: open an issue and `@claude`
 
-Open the [stipend data issue template](https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose) and describe what you know — a link to your department's funding page, an offer letter or payroll PDF (with personal info redacted), or just the numbers. Then `@claude` in a comment on the issue, and the [Claude PR Assistant workflow](.github/workflows/claude.yml) will draft the CSV change as a pull request for maintainers to review. Please keep the original source link or document handy — maintainers will verify before merging, and verified submissions get a checkmark on the website.
+Open the [stipend data issue template](https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose) and describe what you know — a link to your department's funding page, an offer letter or payroll PDF (with personal info redacted), or just the numbers. Then `@claude` in a comment on the issue, and the [Claude PR Assistant workflow](.github/workflows/claude.yml) will draft the CSV change as a pull request for maintainers to review. If you have a source document link or can upload a (redacted) copy, we can add a verified checkmark on the website — it's optional, but encouraged.
 
 ### Editing the CSVs directly
 

--- a/faq.html
+++ b/faq.html
@@ -185,8 +185,9 @@
                     opening an <a
                         href="https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose">issue on
                         GitHub</a>. After opening an issue, you can <code>@claude</code> in a comment and the Claude PR
-                    Assistant will draft the CSV change as a pull request for maintainers to review. Please always
-                    include a source link or a (redacted) source document so maintainers can verify before merging.
+                    Assistant will draft the CSV change as a pull request for maintainers to review. Source documents
+                    are optional but encouraged &mdash; if you share a link or upload a (redacted) copy, we can add a
+                    verified checkmark on the website.
                 </p>
                 <h2>What's your plan for the future? Will X, Y, and Z be added?</h2>
                 <p>

--- a/index.html
+++ b/index.html
@@ -425,8 +425,8 @@
             it provides the advantage of creating a hyperlink on the checkmark that directs to the corresponding issue. In most cases, we will respond
             to a submitted issue within a few days.
             After opening an issue, you can <code>@claude</code> in a comment and our Claude PR Assistant will draft the
-            CSV change as a pull request for review &mdash; please always include a source link or a (redacted) source
-            document so maintainers can verify before merging.
+            CSV change as a pull request for review. Source documents are optional but encouraged &mdash; if you share
+            a link or upload a (redacted) copy, we can add a verified checkmark on the website.
           </p>
           <p>
             <b>Frequent-Asked Questions:</b> Please see FAQs <a href="/faq.html" target="_blank">here</a>.


### PR DESCRIPTION
## Summary
- Reframe the source-link / source-document language across README, FAQ, landing page, and the issue/PR templates: it's optional, not required.
- A shared link or (redacted) upload is what qualifies an entry for the verified checkmark on the site.

## Test plan
- [ ] Render README on the PR page and confirm the contribution paragraph reads as optional/encouraged.
- [ ] Open a draft against the issue template locally and confirm the prompt no longer asks for a source up front.
- [ ] Load `index.html` and `faq.html` via `python3 -m http.server` to confirm the updated paragraphs render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)