### PR TITLE
fix: round Kansas State University fee to integer

### DIFF
--- a/stipend-us.csv
+++ b/stipend-us.csv
@@ -66,5 +66,5 @@ institution, pre_qual stipend, after_qual stipend, fee, public/private, labels, 
 "University of Tennessee - Knoxville", 35328, 35328, 0, public, summer-gtd, 8832, 8832, Y12 https://github.com/CSStipendRankings/CSStipendRankings/issues/136, Y12 https://github.com/CSStipendRankings/CSStipendRankings/issues/136
 "University of Oregon", 23232, 23232, 183, public, summer-no-gtd, Unknown, Unknown, No, No
 "University of Minnesota", 32989, 32989, 325, public, summer-no-gtd, 8403, 8403, Yes https://cse.umn.edu/cs/assistantships, Yes https://cse.umn.edu/cs/assistantships
-"Kansas State University (CS)", 14400, 14400, 1378.48, public, summer-no-gtd varies, Unknown, Unknown, No, No
+"Kansas State University (CS)", 14400, 14400, 1378, public, summer-no-gtd varies, Unknown, Unknown, No, No
 "Vanderbilt University", 40000, 40000, 0, private, summer-gtd, Unknown, Unknown, No, No


### PR DESCRIPTION
Fix: Kansas State University fee field from `1378.48` to `1378` to comply with the integer-only money formatting rule in the CSVs.