### PR TITLE
docs: bold EPI license note, add overestimation caveat and sponsor call

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,7 +241,7 @@
                 working to collect such data. For now, this data is not complete.
               </li>
               <li>Fees are annual non-reimbursible tariffs (including health insurance) reclaimed by said institution. <b>See why health insurance is included in <a href="/faq.html#:~:text=Why is health insurance included in fees?" target="_blank">here.</a></b> If the institution charges a CPT fee or summer enrollment fee for international students, they should also be counted here. <b>In short, this should be the maximum possible fee that the institution charges.</b></li>
-              <li>Living cost is based on the institution's county, using the <a href="https://www.epi.org/resources/budget/" target="_blank">EPI Family Budget Calculator</a> (1 adult, 0 children). We recently switched to the EPI calculator because its more relaxed license allows us to download raw data for automatic updates.</li>
+              <li>Living cost is based on the institution's county, using the <a href="https://www.epi.org/resources/budget/" target="_blank">EPI Family Budget Calculator</a> (1 adult, 0 children). We recently switched to the EPI calculator because <b>its more relaxed license allows us to download raw data for automatic updates</b>. We note that it sometimes overestimates the cost, but this is the only one we can find with such a relaxed license. If you can sponsor us with better data, it's more than welcomed.</li>
             </ul>
             <p>We use the following labels on the website:
               <ul>


### PR DESCRIPTION
- Bold the EPI relaxed-license justification
- Add note that EPI sometimes overestimates cost
- Add call for sponsors with better data