### PR TITLE
fix: correct /opencode trigger description — runs on issue open, not just comment

### DIFF
--- a/index.html
+++ b/index.html
@@ -417,9 +417,10 @@
             We encourage submitting datapoints through issues due to its ability to facilitate public discussion. Additionally,
             it provides the advantage of creating a hyperlink on the checkmark that directs to the corresponding issue. In most cases, we will respond
             to a submitted issue within a few days.
-            After opening an issue, you can <code>/opencode</code> in a comment and our OpenCode PR Assistant will draft the
-            CSV change as a pull request for review. Source documents are optional but encouraged &mdash; if you share
-            a link or upload a (redacted) copy, we can add a verified checkmark on the website.
+            The OpenCode PR Assistant automatically reviews new issues and drafts CSV changes as a pull request.
+            You can also trigger a re-run by commenting <code>/opencode</code> on any issue. Source documents are
+            optional but encouraged &mdash; if you share a link or upload a (redacted) copy, we can add a verified
+            checkmark on the website.
           </p>
           <p>
             <b>Frequent-Asked Questions:</b> Please see FAQs <a href="/faq.html" target="_blank">here</a>.


### PR DESCRIPTION
Update text to reflect that OpenCode automatically reviews issues on creation, not only when `/opencode` is commented.