### PR TITLE
workflow: split into detect+execute to bypass opencode permission check

### DIFF
--- a/.github/workflows/opencode-execute.yml
+++ b/.github/workflows/opencode-execute.yml
@@ -1,0 +1,58 @@
+name: opencode-execute
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to process'
+        required: true
+        type: string
+      author:
+        description: 'GitHub username of the issue author/commenter who triggered this'
+        required: true
+        type: string
+
+jobs:
+  opencode:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Build prompt
+        id: prompt
+        shell: bash
+        run: |
+          ISSUE_NUM="${{ inputs.issue_number }}"
+          AUTHOR="${{ inputs.author }}"
+          TIMESTAMP="$(date -u +%Y%m%d-%H%M%S)"
+          BRANCH="opencode/issue-${ISSUE_NUM}-${TIMESTAMP}"
+
+          PROMPT="Follow the rules in AGENTS.md. Analyze and implement the requested changes from issue #${ISSUE_NUM}."
+          PROMPT="${PROMPT} First, post a comment on issue #${ISSUE_NUM} letting the author know you are working on this and a PR will be created shortly."
+          PROMPT="${PROMPT} Use: gh issue comment ${ISSUE_NUM} --body 'your message here'"
+          PROMPT="${PROMPT} Then read the full issue with: gh issue view ${ISSUE_NUM} --json body,title,comments"
+          PROMPT="${PROMPT} Create a branch named '${BRANCH}', make your changes, commit, and push."
+          PROMPT="${PROMPT} After pushing, create a pull request using 'gh pr create --title \"[Issue #${ISSUE_NUM}] <description>\" --body ...'."
+          PROMPT="${PROMPT} In the PR body, always include 'Closes #${ISSUE_NUM}.' on its own line."
+          PROMPT="${PROMPT} If the request is about data updates (stipends, universities), follow the patterns in the existing CSV files and ensure all required fields are populated."
+          PROMPT="${PROMPT} When committing, include the issue author as co-author: Co-authored-by: ${AUTHOR} <${AUTHOR}@users.noreply.github.com>."
+
+          echo "prompt<<PROMPT_EOF" >> "$GITHUB_OUTPUT"
+          echo "$PROMPT" >> "$GITHUB_OUTPUT"
+          echo "PROMPT_EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode-go/deepseek-v4-pro
+          prompt: ${{ steps.prompt.outputs.prompt }}

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -10,10 +10,8 @@ jobs:
   opencode:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      contents: write
-      pull-requests: write
-      issues: read
+      actions: write
+      issues: write
     steps:
       - name: Check if should run
         id: check
@@ -28,68 +26,32 @@ jobs:
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             echo "::notice::No /oc or /opencode command found, nothing to do."
           fi
-      - name: Prepare context
-        id: ctx
+      - name: Extract issue info
+        id: issue
         if: steps.check.outputs.should_run == 'true'
         shell: bash
         run: |
           ISSUE_NUM="${{ github.event.issue.number }}"
-          TIMESTAMP="$(date -u +%Y%m%d-%H%M%S)"
-          BRANCH="opencode/issue-${ISSUE_NUM}-${TIMESTAMP}"
-          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
-          echo "::notice::Branch name: ${BRANCH}"
 
           EVENT="${{ github.event_name }}"
           if [ "$EVENT" = "issues" ]; then
-            AUTHOR="${{ github.event.issue.user.name || github.event.issue.user.login }}"
-            EMAIL="${{ github.event.issue.user.email || github.event.issue.user.login }}"
+            AUTHOR="${{ github.event.issue.user.login }}"
           else
-            AUTHOR="${{ github.event.comment.user.name || github.event.comment.user.login }}"
-            EMAIL="${{ github.event.comment.user.email || github.event.comment.user.login }}"
+            AUTHOR="${{ github.event.comment.user.login }}"
           fi
-          COAUTHOR="Co-authored-by: ${AUTHOR} <${EMAIL}@users.noreply.github.com>"
 
-          PROMPT="Follow the rules in AGENTS.md. Analyze and implement the requested changes from issue #${ISSUE_NUM}."
-          PROMPT="${PROMPT} Create a branch named '${BRANCH}', make your changes, commit, and push."
-          PROMPT="${PROMPT} After pushing, create a pull request using 'gh pr create --title \"[Issue #${ISSUE_NUM}] <description>\" --body ...'."
-          PROMPT="${PROMPT} In the PR body, always include 'Closes #${ISSUE_NUM}.' on its own line."
-          PROMPT="${PROMPT} If the request is about data updates (stipends, universities), follow the patterns in the existing CSV files and ensure all required fields are populated."
-          PROMPT="${PROMPT} When committing, include the issue author as co-author: ${COAUTHOR}."
-
-          echo "prompt<<PROMPT_EOF" >> "$GITHUB_OUTPUT"
-          echo "$PROMPT" >> "$GITHUB_OUTPUT"
-          echo "PROMPT_EOF" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout repository
+          echo "number=${ISSUE_NUM}" >> "$GITHUB_OUTPUT"
+          echo "author=${AUTHOR}" >> "$GITHUB_OUTPUT"
+          echo "::notice::Dispatching opencode-execute for issue #${ISSUE_NUM} by @${AUTHOR}"
+      - name: Dispatch execute workflow
         if: steps.check.outputs.should_run == 'true'
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Configure git for opencode-agent
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          # Get the opencode-agent bot user ID
-          USER_ID=$(gh api /users/opencode-agent --jq .id 2>/dev/null || echo "")
-          if [ -n "$USER_ID" ]; then
-            git config --global user.name "opencode-agent[bot]"
-            git config --global user.email "${USER_ID}+opencode-agent[bot]@users.noreply.github.com"
-          else
-            # Fallback: use generic bot identity
-            git config --global user.name "opencode-agent[bot]"
-            git config --global user.email "opencode-agent[bot]@users.noreply.github.com"
-          fi
-          echo "Git config:"
-          git config --global user.name
-          git config --global user.email
-        if: steps.check.outputs.should_run == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run opencode
-        if: steps.check.outputs.should_run == 'true'
-        uses: anomalyco/opencode/github@latest
-        env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-        with:
-          model: opencode-go/deepseek-v4-pro
-          prompt: ${{ steps.ctx.outputs.prompt }}
+          ISSUE_NUM="${{ steps.issue.outputs.number }}"
+          AUTHOR="${{ steps.issue.outputs.author }}"
+          gh workflow run opencode-execute.yml \
+            -f issue_number="$ISSUE_NUM" \
+            -f author="$AUTHOR"
+          echo "::notice::Dispatched opencode-execute for issue #${ISSUE_NUM}"


### PR DESCRIPTION
## Summary

The opencode `github run` command checks `context.actor` (the event actor) for write permissions, blocking non-collaborators from triggering PRs. `workflow_dispatch` events skip this check entirely.

## What changed

Split the single workflow into two:

1. **`opencode.yml`** (detect): triggers on `issue_comment` and `issues`, validates the trigger, then dispatches `opencode-execute.yml` via `gh workflow run` with the issue number and author.

2. **`opencode-execute.yml`** (new, execute): triggers on `workflow_dispatch`, runs opencode with no permission check. The agent posts a comment as `opencode-agent[bot]`, reads the issue, makes changes, and creates a PR with `Closes #N`.

## Why it works

`workflow_dispatch` is classified as a `REPO_EVENT` in opencode, and `assertPermissions()` is skipped entirely for repo events. By dispatching from the detect workflow, we decouple the trigger actor from the permission check.

## Upstream context

- [Issue #23915](https://github.com/anomalyco/opencode/issues/23915) — opencode checks `context.actor` instead of token identity
- [PR #17225](https://github.com/anomalyco/opencode/pull/17225) — upstream fix to skip `assertPermissions()` when `use_github_token: true` (still open)