### PR TITLE
fix: add --repo flag to gh workflow run to resolve missing git repo error

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -52,6 +52,7 @@ jobs:
           ISSUE_NUM="${{ steps.issue.outputs.number }}"
           AUTHOR="${{ steps.issue.outputs.author }}"
           gh workflow run opencode-execute.yml \
+            --repo "${{ github.repository }}" \
             -f issue_number="$ISSUE_NUM" \
             -f author="$AUTHOR"
           echo "::notice::Dispatched opencode-execute for issue #${ISSUE_NUM}"


### PR DESCRIPTION
## Summary
- `gh workflow run` in `opencode.yml` fails because the job has no `actions/checkout`, so there's no `.git` directory and `gh` can't infer the target repository.
- Added `--repo "${{ github.repository }}"` to explicitly tell `gh` which repository to dispatch to.

Fixes: `failed to run git: fatal: not a git repository` error on issue trigger.