### PR TITLE
fix: remove --print-logs and --log-level DEBUG from opencode invocation

### DIFF
--- a/.github/workflows/opencode-execute.yml
+++ b/.github/workflows/opencode-execute.yml
@@ -69,4 +69,4 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           MODEL: opencode-go/deepseek-v4-pro
           PROMPT: ${{ steps.prompt.outputs.prompt }}
-        run: opencode github run --print-logs --log-level DEBUG
+        run: opencode github run


### PR DESCRIPTION
## Summary
- Remove `--print-logs` and `--log-level DEBUG` flags that flooded the GitHub Actions log with internal framework bus messages (e.g. `service=bus type=message.part.delta publishing`)
- The `opencode github run` command already prints tool calls and agent text responses to stdout via its own event handler
- Note: LLM reasoning/thinking blocks are not surfaced by the github run command — this requires a code change in opencode itself (the `subscribeSessionEvents` handler only processes `tool` and `text` part types, not `reasoning`)