### PR TITLE
fix: restore composite action to prevent permission hang in CI

### DIFF
--- a/.github/workflows/opencode-execute.yml
+++ b/.github/workflows/opencode-execute.yml
@@ -55,18 +55,10 @@ jobs:
           gh issue comment "${{ inputs.issue_number }}" \
             --body "Starting to work on this — I'll open a PR shortly."
 
-      - name: Install opencode
-        shell: bash
-        run: curl -fsSL https://opencode.ai/install | bash
-
-      - name: Add opencode to PATH
-        shell: bash
-        run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
-
       - name: Run opencode
-        shell: bash
+        uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          MODEL: opencode-go/deepseek-v4-pro
-          PROMPT: ${{ steps.prompt.outputs.prompt }}
-        run: opencode github run
+        with:
+          model: opencode-go/deepseek-v4-pro
+          prompt: ${{ steps.prompt.outputs.prompt }}


### PR DESCRIPTION
## Summary
- The direct CLI invocation (`opencode github run`) caused `permission.asked` events to hang indefinitely because the command's event handler doesn't auto-resolve `external_directory` access permissions in CI
- Restoring the `anomalyco/opencode/github@latest` composite action, which worked reliably before
- Retains the "Post working-on comment" step added in PR #190
- Retains the simplified prompt (no more agent-posts-comment instructions)