### PR TITLE
move EPI calculator rationale from index to FAQ

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -130,39 +130,19 @@
                 <h2 id="why-epi">Why EPI Family Budget Calculator?</h2>
                 <p>
                     We use the <a href="https://www.epi.org/resources/budget/" target="_blank">EPI Family Budget Calculator</a>
-                    (1 adult, 0 children, denoted 1p0c) as the primary source for living cost data.
-                    EPI values include a comprehensive set of cost components: housing, food, transportation,
-                    healthcare, other necessities, and taxes. The EPI calculator provides more complete
-                    cost-of-living estimates at the county level compared to other calculators.
-                    If you are aware of other data sources we should consider, please feel free
-                    to submit <a
-                        href="https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose">issues</a> or <a
-                        href="https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose">pull
-                        requests</a> on GitHub.
-                    We are aware that while the EPI Family Budget Calculator is
-                    useful for comparing costs of living across the country, it has its limitations. There are two
-                    issues flagged by our users:
-                <ul>
-                    <li>
-                        Data is often unavailable for the precise district in which the university is located. In such
-                        cases, we use data for the county or wider metro area.
-                        This often makes places look more affordable than they actually are. For instance, UC San Diego
-                        is located in La Jolla, one of the most expensive districts in the US, but we resort
-                        to using figures for the wider San Diego county. Same goes for Westwood (UCLA) vs. LA County,
-                        Princeton vs. Mercer County, etc.
-                    </li>
-                    <li>
-                        The calculator states that the estimates are what is required "to attain a modest
-                        yet adequate standard of living" in a given community.
-                        However, how much one needs to sustain oneself is subjective, and users have reported that they
-                        can live on much less.
-                    </li>
-                </ul>
+                    (1 adult, 0 children, denoted 1p0c) for living-cost data.
+                    EPI covers housing, food, transportation, healthcare, other necessities, and taxes at the county level.
+                    We chose it primarily because its license lets us download raw data for automated updates.
                 </p>
                 <p>
-                    We recently switched to the EPI calculator because its more relaxed license allows us to download raw data for automatic updates.
-                    We note that EPI sometimes overestimates living costs, but this is the most suitable calculator we have found with a permissive enough license.
-                    If you can sponsor us with better living-cost data, please <a href="https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose">submit an issue</a>.
+                    <strong>Limitations:</strong> EPI data is county-level, which can understate costs in pricier
+                    districts within a county (e.g. La Jolla vs. San Diego County, Westwood vs. LA County).
+                    The estimates target a "modest yet adequate" standard; individual budgets vary, and some students
+                    report living on less.
+                </p>
+                <p>
+                    If you know of a better data source with a permissive license,
+                    please <a href="https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose">submit an issue or pull request</a>.
                 </p>
                 <h2>Why is health insurance included in fees?</h2>
                 <p>

--- a/faq.html
+++ b/faq.html
@@ -127,7 +127,7 @@
                     for at least a subset of their PhD students. This label will be kept until the department proves such support is guaranteed (i.e.,
                     via an official letter with department letterhead and signatures).
                 </p>
-                <h2>Why EPI Family Budget Calculator?</h2>
+                <h2 id="why-epi">Why EPI Family Budget Calculator?</h2>
                 <p>
                     We use the <a href="https://www.epi.org/resources/budget/" target="_blank">EPI Family Budget Calculator</a>
                     (1 adult, 0 children, denoted 1p0c) as the primary source for living cost data.
@@ -158,6 +158,11 @@
                         can live on much less.
                     </li>
                 </ul>
+                </p>
+                <p>
+                    We recently switched to the EPI calculator because its more relaxed license allows us to download raw data for automatic updates.
+                    We note that EPI sometimes overestimates living costs, but this is the most suitable calculator we have found with a permissive enough license.
+                    If you can sponsor us with better living-cost data, please <a href="https://github.com/CSStipendRankings/CSStipendRankings/issues/new/choose">submit an issue</a>.
                 </p>
                 <h2>Why is health insurance included in fees?</h2>
                 <p>

--- a/index.html
+++ b/index.html
@@ -241,7 +241,7 @@
                 working to collect such data. For now, this data is not complete.
               </li>
               <li>Fees are annual non-reimbursible tariffs (including health insurance) reclaimed by said institution. <b>See why health insurance is included in <a href="/faq.html#:~:text=Why is health insurance included in fees?" target="_blank">here.</a></b> If the institution charges a CPT fee or summer enrollment fee for international students, they should also be counted here. <b>In short, this should be the maximum possible fee that the institution charges.</b></li>
-              <li>Living cost is based on the institution's county, using the <a href="https://www.epi.org/resources/budget/" target="_blank">EPI Family Budget Calculator</a> (1 adult, 0 children). We recently switched to the EPI calculator because <b>its more relaxed license allows us to download raw data for automatic updates</b>. We note that it sometimes overestimates the cost, but this is the only one we can find with such a relaxed license. If you can sponsor us with better data, it's more than welcomed.</li>
+              <li>Living cost is based on the institution's county, using the <a href="https://www.epi.org/resources/budget/" target="_blank">EPI Family Budget Calculator</a> (1 adult, 0 children). See the <a href="/faq.html#why-epi" target="_blank">FAQ</a> for details on our choice of data source.</li>
             </ul>
             <p>We use the following labels on the website:
               <ul>


### PR DESCRIPTION
## Summary
- Shortens the EPI calculator description in `index.html` to a concise one-liner with a link to the FAQ
- Moves the detailed rationale (license permitting automatic updates, overestimation caveat, sponsorship invitation) to `faq.html` under the existing EPI section
- Adds `id="why-epi"` anchor to the FAQ heading for direct linking